### PR TITLE
Replace browser alerts with in-app notifications

### DIFF
--- a/src/NotificationContext.js
+++ b/src/NotificationContext.js
@@ -1,0 +1,23 @@
+import React, { useState, useContext, createContext } from 'react';
+
+const NotificationContext = createContext();
+
+export function NotificationProvider({ children }) {
+  const [message, setMessage] = useState('');
+  const [visible, setVisible] = useState(false);
+
+  const show = msg => {
+    setMessage(msg);
+    setVisible(true);
+    setTimeout(() => setVisible(false), 4000);
+  };
+
+  return (
+    <NotificationContext.Provider value={{ show }}>
+      {visible && <div className="notification">{message}</div>}
+      {children}
+    </NotificationContext.Provider>
+  );
+}
+
+export const useNotification = () => useContext(NotificationContext);

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -14,6 +14,7 @@ import {
   signInWithEmailAndPassword
 } from 'firebase/auth';
 import { doc, getDoc } from 'firebase/firestore';
+import { useNotification } from '../NotificationContext';
 
 const slideDown = keyframes`
   from { opacity: 0; transform: translateY(-10px); }
@@ -244,6 +245,8 @@ const PopupButton = styled.button`
   font-weight: 700;
   cursor: pointer;
   margin-bottom: 1rem;
+  opacity: ${p => (p.disabled ? 0.6 : 1)};
+  pointer-events: ${p => (p.disabled ? 'none' : 'auto')};
   transition: background-color 0.2s ease, transform 0.2s ease;
   &:hover {
     background-color: ${({ theme }) => theme.colors.accent};
@@ -319,12 +322,14 @@ const InfoText = styled.p`
 `;
 
 export default function Navbar() {
+  const { show } = useNotification();
   const [open, setOpen] = useState(false);
   const [user, setUser] = useState(null);
   const [userData, setUserData] = useState(null);
   const [loginEmail, setLoginEmail] = useState('');
   const [loginPassword, setLoginPassword] = useState('');
   const [loginOpen, setLoginOpen] = useState(false);
+  const [loggingIn, setLoggingIn] = useState(false);
   const loginRef = useRef(null);
   const navigate = useNavigate();
 
@@ -360,6 +365,8 @@ export default function Navbar() {
   };
 
   const handleLogin = async () => {
+    if (loggingIn) return;
+    setLoggingIn(true);
     try {
       const userCredential = await signInWithEmailAndPassword(auth, loginEmail, loginPassword);
       const u = userCredential.user;
@@ -379,7 +386,9 @@ export default function Navbar() {
       setLoginPassword('');
       setLoginOpen(false);
     } catch (err) {
-      alert('Error al iniciar sesión: ' + err.message);
+      show(`Error al iniciar sesión: ${err.message}`);
+    } finally {
+      setLoggingIn(false);
     }
   };
 
@@ -466,7 +475,7 @@ export default function Navbar() {
                     value={loginPassword}
                     onChange={e => setLoginPassword(e.target.value)}
                   />
-                  <PopupButton onClick={handleLogin}>
+                  <PopupButton onClick={handleLogin} disabled={loggingIn}>
                     Iniciar sesión
                   </PopupButton>
                   <PopupRegister>

--- a/src/index.css
+++ b/src/index.css
@@ -9,3 +9,16 @@
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
+
+.notification {
+  position: fixed;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #034640;
+  color: #fff;
+  padding: 0.8rem 1.2rem;
+  border-radius: 8px;
+  z-index: 1000;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import { NotificationProvider } from "./NotificationContext";
 import reportWebVitals from './reportWebVitals';
 import { ThemeProvider } from 'styled-components';
 import { theme, GlobalStyle } from './theme';
@@ -12,7 +13,9 @@ root.render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <App />
+            <NotificationProvider>
+        <App />
+      </NotificationProvider>
     </ThemeProvider>
   </React.StrictMode>
 );

--- a/src/screens/SignUpProfesor.jsx
+++ b/src/screens/SignUpProfesor.jsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import styled, { keyframes } from 'styled-components';
 import { useNavigate } from 'react-router-dom';
+import { useNotification } from "../NotificationContext";
 
 // Firebase (inicializado en firebaseConfig.js)
 import { auth, db } from '../firebase/firebaseConfig';
@@ -31,6 +32,8 @@ const Card = styled.div`
   box-shadow: 0 14px 36px rgba(0,0,0,0.15);
   padding: 3rem 2rem;
   width: 100%;
+  opacity: ${p => (p.disabled ? 0.6 : 1)};
+  pointer-events: ${p => (p.disabled ? "none" : "auto")};
   max-width: 520px;
   animation: ${fadeIn} 0.6s ease-out;
 `;
@@ -103,6 +106,8 @@ const Field = styled.div`
 const DropdownContainer = styled.div`
   position: relative;
   width: 100%;
+  opacity: ${p => (p.disabled ? 0.6 : 1)};
+  pointer-events: ${p => (p.disabled ? "none" : "auto")};
 `;
 const DropdownHeader = styled.div`
   padding: 0.7rem 0.9rem;
@@ -148,6 +153,8 @@ const Arrow = styled.span`
 // Botón principal
 const Button = styled.button`
   width: 100%;
+  opacity: ${p => (p.disabled ? 0.6 : 1)};
+  pointer-events: ${p => (p.disabled ? "none" : "auto")};
   padding: 0.9rem;
   margin-top: 1.8rem;
   background: #034640;
@@ -218,7 +225,9 @@ export default function SignUpProfesor() {
   const [cities, setCities]           = useState([]);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [modalOpen, setModalOpen]     = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   const navigate = useNavigate();
+  const { show } = useNotification();
   const ref = useRef();
 
   // Carga ciudades
@@ -245,12 +254,15 @@ export default function SignUpProfesor() {
   }, []);
 
   const handleSubmit = async () => {
+    if (submitting) return;
     if (!email || !password || !confirmPassword || !nombre || !apellido || !telefono || !ciudad) {
-      return alert('Completa todos los campos');
+      show('Completa todos los campos');
+      return;
     }
     if (password !== confirmPassword) {
-      return alert('Las contraseñas no coinciden');
+      return show('Las contraseñas no coinciden');
     }
+    setSubmitting(true);
     try {
       const { user } = await createUserWithEmailAndPassword(auth, email, password);
       await setDoc(doc(db, 'usuarios', user.uid), {
@@ -263,11 +275,13 @@ export default function SignUpProfesor() {
         rol: 'profesor',
         createdAt: new Date()
       });
-      alert('Profesor registrado con éxito');
+      show('Profesor registrado con éxito');
       navigate('/');
     } catch (err) {
       console.error(err);
-      alert('Error: ' + err.message);
+      show('Error: ' + err.message);
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -350,7 +364,7 @@ export default function SignUpProfesor() {
             </DropdownContainer>
           </Field>
         </FormGrid>
-        <Button onClick={handleSubmit}>Crear cuenta de profesor</Button>
+        <Button onClick={handleSubmit} disabled={submitting}>Crear cuenta de profesor</Button>
       </Card>
 
       {modalOpen && (

--- a/src/screens/profesor/acciones/MisAlumnos.jsx
+++ b/src/screens/profesor/acciones/MisAlumnos.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { useNotification } from "../../../NotificationContext";
 import styled, { keyframes } from 'styled-components';
 import { auth, db } from '../../../firebase/firebaseConfig';
 import {
@@ -260,6 +261,7 @@ export default function MisAlumnos() {
   const [proposals, setProposals] = useState([]);
   const [input, setInput] = useState('');
   const [openProposalModal, setOpenProposalModal] = useState(false);
+  const { show } = useNotification();
   const [selectedUnion, setSelectedUnion] = useState(null);
   const [fechaClase, setFechaClase] = useState('');
   const [duracion, setDuracion] = useState('');
@@ -342,7 +344,8 @@ export default function MisAlumnos() {
   // 6. Envía la propuesta de clase
   const submitProposal = async () => {
     if (!fechaClase || !duracion || !asignMateria) {
-      return alert('Rellena todos los campos de la propuesta de clase');
+      show('Rellena todos los campos de la propuesta de clase');
+      return;
     }
     const durNum = parseFloat(duracion);
 
@@ -361,7 +364,7 @@ export default function MisAlumnos() {
       }
     );
     setOpenProposalModal(false);
-    alert('Propuesta de clase enviada al alumno');
+    show('Propuesta de clase enviada al alumno');
     // NOTA: **No** agregamos un mensaje separado en “chats”;
     // la burbuja desaparecerá de “proposals” cuando el alumno responda.
   };


### PR DESCRIPTION
## Summary
- add global notification context
- display messages using NotificationProvider
- wrap the app with provider
- replace `alert()` calls with on-screen notifications
- disable submit buttons while submitting to avoid duplicate entries

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684173370804832badfa5ecf000e1b49