### PR TITLE
Implement role-based access control

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 // src/App.js
 import React from 'react';
 import { BrowserRouter, Routes, Route, Navigate, Outlet } from 'react-router-dom';
+import RequireAuth from './components/RequireAuth';
 import styled from 'styled-components';
 
 import ScrollToTop     from './components/ScrollToTop';
@@ -65,20 +66,26 @@ export default function App() {
             {/* Ruta de perfil con parámetro userId */}
             <Route path="/perfil/:userId"       element={<Perfil />} />
 
-            <Route path="/alumno"               element={<PanelAlumno />} />
-            <Route path="/alumno/nueva-clase"   element={<NuevaClase />} />
-            <Route path="/alumno/clases"        element={<Clases />} />
-            <Route path="/alumno/calendario"    element={<CalendarioA />} />
-            <Route path="/profesor/mis-profesores" element={<MisProfesores />} />
+            <Route element={<RequireAuth allowedRoles={['alumno','padre','admin']} />}>
+              <Route path="/alumno"               element={<PanelAlumno />} />
+              <Route path="/alumno/nueva-clase"   element={<NuevaClase />} />
+              <Route path="/alumno/clases"        element={<Clases />} />
+              <Route path="/alumno/calendario"    element={<CalendarioA />} />
+              <Route path="/profesor/mis-profesores" element={<MisProfesores />} />
+            </Route>
 
-            <Route path="/admin"                element={<PanelAdmin />} />
-            <Route path="/admin/acciones/gestion-clases" element={<GestionClases />} />
+            <Route element={<RequireAuth allowedRoles={['admin']} />}>
+              <Route path="/admin"                element={<PanelAdmin />} />
+              <Route path="/admin/acciones/gestion-clases" element={<GestionClases />} />
+            </Route>
 
-            <Route path="/profesor"             element={<PanelProfesor />} />
-            <Route path="/profesor/ofertas"     element={<Ofertas />} />
-            <Route path="/profesor/calendario"  element={<CalendarioP />} />
-            <Route path="/profesor/mis-clases"  element={<ClasesProfesor />} />
-            <Route path="/profesor/mis-alumnos" element={<MisAlumnos />} />
+            <Route element={<RequireAuth allowedRoles={['profesor','admin']} />}>
+              <Route path="/profesor"             element={<PanelProfesor />} />
+              <Route path="/profesor/ofertas"     element={<Ofertas />} />
+              <Route path="/profesor/calendario"  element={<CalendarioP />} />
+              <Route path="/profesor/mis-clases"  element={<ClasesProfesor />} />
+              <Route path="/profesor/mis-alumnos" element={<MisAlumnos />} />
+            </Route>
 
             {/* Rutas públicas */}
             <Route path="/reserva-tu-clase"     element={<ReservaClase />} />

--- a/src/AuthContext.js
+++ b/src/AuthContext.js
@@ -1,0 +1,39 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { auth, db } from './firebase/firebaseConfig';
+import { onAuthStateChanged } from 'firebase/auth';
+import { doc, getDoc } from 'firebase/firestore';
+
+const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const [userData, setUserData] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async u => {
+      setUser(u);
+      if (u) {
+        try {
+          const snap = await getDoc(doc(db, 'usuarios', u.uid));
+          setUserData(snap.exists() ? snap.data() : null);
+        } catch (err) {
+          console.error(err);
+          setUserData(null);
+        }
+      } else {
+        setUserData(null);
+      }
+      setLoading(false);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, userData, loading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/src/components/RequireAuth.jsx
+++ b/src/components/RequireAuth.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '../AuthContext';
+
+export default function RequireAuth({ allowedRoles }) {
+  const { user, userData, loading } = useAuth();
+
+  if (loading) return null;
+
+  if (!user) {
+    return <Navigate to="/home" replace />;
+  }
+
+  if (allowedRoles && userData && !allowedRoles.includes(userData.rol)) {
+    return <Navigate to="/home" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,8 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
-import { NotificationProvider } from "./NotificationContext";
+import { NotificationProvider } from './NotificationContext';
+import { AuthProvider } from './AuthContext';
 import reportWebVitals from './reportWebVitals';
 import { ThemeProvider } from 'styled-components';
 import { theme, GlobalStyle } from './theme';
@@ -13,9 +14,11 @@ root.render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-            <NotificationProvider>
-        <App />
-      </NotificationProvider>
+      <AuthProvider>
+        <NotificationProvider>
+          <App />
+        </NotificationProvider>
+      </AuthProvider>
     </ThemeProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add AuthContext to provide logged user and role
- add RequireAuth wrapper for protected routes
- wrap App with AuthProvider
- protect admin, professor and student routes with RequireAuth

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c50d18ac832bafe930c8591cbcce