### PR TITLE
Add modality and earnings tracking

### DIFF
--- a/src/screens/alumno/acciones/MisProfesores.jsx
+++ b/src/screens/alumno/acciones/MisProfesores.jsx
@@ -355,6 +355,7 @@ export default function MisProfesores() {
                           <strong>{item.asignatura}</strong> para el{' '}
                           <strong>{item.fecha}</strong> ({item.duracion}h)
                         </div>
+                        <div>Coste: €{(item.precioTotalPadres || 0).toFixed(2)}</div>
                         <AcceptButton onClick={() => acceptProposal(item)}>
                           Aceptar
                         </AcceptButton>

--- a/src/screens/shared/Perfil.jsx
+++ b/src/screens/shared/Perfil.jsx
@@ -182,9 +182,9 @@ export default function Perfil() {
       0
     );
 
-    // 3.2) Total facturado (sumar precioTotal)
+    // 3.2) Total facturado (sumar precioTotalPadres)
     const totalFacturado = acceptedClasses.reduce(
-      (acc, c) => acc + (c.precioTotal || 0),
+      (acc, c) => acc + (c.precioTotalPadres || 0),
       0
     );
 
@@ -192,14 +192,14 @@ export default function Perfil() {
     const totalGastado =
       role === 'alumno'
         ? acceptedClasses.reduce(
-            (acc, c) => acc + (c.precioTotal || 0),
+            (acc, c) => acc + (c.precioTotalPadres || 0),
             0
           )
         : 0;
     const totalGanado =
       role === 'profesor'
         ? acceptedClasses.reduce(
-            (acc, c) => acc + (c.precioTotal || 0),
+            (acc, c) => acc + (c.precioTotalProfesor || 0),
             0
           )
         : 0;
@@ -212,7 +212,7 @@ export default function Perfil() {
       const mes = c.fecha.slice(0, 7); // "YYYY-MM"
       if (!agrupado[mes]) agrupado[mes] = { mes, horas: 0, facturado: 0 };
       agrupado[mes].horas += c.duracion || 0;
-      agrupado[mes].facturado += c.precioTotal || 0;
+      agrupado[mes].facturado += c.precioTotalPadres || 0;
     });
     const dataGrafico = Object.values(agrupado).sort((a, b) => {
       return (


### PR DESCRIPTION
## Summary
- enable teachers to specify modality and select subject from dropdown
- store price information when proposing classes
- display cost for students when receiving a proposal
- compute earnings and spending using stored totals

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c3e76cf0832ba098862e7c189a79