### PR TITLE
Add redirect for logged in users

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route, Navigate, Outlet } from 'react-router-dom';
 import RequireAuth from './components/RequireAuth';
+import RedirectLoggedIn from './components/RedirectLoggedIn';
 import styled from 'styled-components';
 
 import ScrollToTop     from './components/ScrollToTop';
@@ -61,7 +62,12 @@ export default function App() {
 
           {/* Con Navbar/Footer */}
           <Route element={<Layout />}>
-            <Route path="/home"                 element={<Home />} />
+            <Route element={<RedirectLoggedIn />}>
+              <Route path="/home"             element={<Home />} />
+              <Route path="/reserva-tu-clase" element={<ReservaClase />} />
+              <Route path="/ser-profesor"     element={<SerProfesor />} />
+              <Route path="/quienes-somos"    element={<QuienesSomos />} />
+            </Route>
 
             {/* Ruta de perfil con parámetro userId */}
             <Route path="/perfil/:userId"       element={<Perfil />} />
@@ -87,12 +93,9 @@ export default function App() {
               <Route path="/profesor/mis-alumnos" element={<MisAlumnos />} />
             </Route>
 
-            {/* Rutas públicas */}
-            <Route path="/reserva-tu-clase"     element={<ReservaClase />} />
-            <Route path="/ser-profesor"         element={<SerProfesor />} />
-            <Route path="/quienes-somos"        element={<QuienesSomos />} />
-            <Route path="/contacto"             element={<Contacto />} />
-            <Route path="/alta"                 element={<Alta />} />
+              {/* Rutas públicas */}
+              <Route path="/contacto"             element={<Contacto />} />
+              <Route path="/alta"                 element={<Alta />} />
 
             {/* Cualquier otra ruta redirige a /home */}
             <Route path="*" element={<Navigate to="/home" replace />} />

--- a/src/components/RedirectLoggedIn.jsx
+++ b/src/components/RedirectLoggedIn.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '../AuthContext';
+
+export default function RedirectLoggedIn() {
+  const { user, userData, loading } = useAuth();
+
+  if (loading) return null;
+
+  if (user && userData) {
+    const target =
+      userData.rol === 'admin'
+        ? '/admin'
+        : userData.rol === 'profesor'
+        ? '/profesor'
+        : '/alumno';
+    return <Navigate to={target} replace />;
+  }
+
+  return <Outlet />;
+}


### PR DESCRIPTION
## Summary
- create `RedirectLoggedIn` component
- redirect `/home`, `/ser-profesor`, `/reserva-tu-clase`, and `/quienes-somos` when logged in

## Testing
- `npm test --silent` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_684388a1e054832ba0939b7c9830bdf5