### PR TITLE
Fix scrolling in chat modal

### DIFF
--- a/src/screens/alumno/acciones/MisProfesores.jsx
+++ b/src/screens/alumno/acciones/MisProfesores.jsx
@@ -194,6 +194,17 @@ export default function MisProfesores() {
   const scrollRef = useRef();
   const navigate = useNavigate();
 
+  // Bloquea el scroll de la página cuando el chat está abierto
+  useEffect(() => {
+    if (chatUnionId) {
+      const prev = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+      return () => {
+        document.body.style.overflow = prev;
+      };
+    }
+  }, [chatUnionId]);
+
   // 1. Carga las uniones (clase-alumno-profesor) donde el usuario es alumno
   useEffect(() => {
     async function fetchUnions() {

--- a/src/screens/profesor/acciones/MisAlumnos.jsx
+++ b/src/screens/profesor/acciones/MisAlumnos.jsx
@@ -267,6 +267,17 @@ export default function MisAlumnos() {
   const scrollRef = useRef();
   const navigate = useNavigate();
 
+  // Bloquea el scroll de la página cuando el chat está abierto
+  useEffect(() => {
+    if (chatUnionId) {
+      const prev = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+      return () => {
+        document.body.style.overflow = prev;
+      };
+    }
+  }, [chatUnionId]);
+
   // 1. Carga las uniones (clase-alumno-profesor) donde el usuario es profesor
   useEffect(() => {
     async function fetchUnions() {


### PR DESCRIPTION
## Summary
- prevent background scrolling when chat modal is open on MisAlumnos and MisProfesores

## Testing
- `npm test --silent` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_684389ebe380832babc0abde7aa7ea89