### PR TITLE
Add profile view with editing and account link

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -254,6 +254,26 @@ const PopupButton = styled.button`
   }
 `;
 
+const PopupLink = styled(Link)`
+  width: 100%;
+  box-sizing: border-box;
+  background-color: ${({ theme }) => theme.colors.secondary};
+  color: ${({ theme }) => theme.colors.primary};
+  padding: 0.75rem;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-weight: 700;
+  text-align: center;
+  text-decoration: none;
+  margin-bottom: 1rem;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.accent};
+    transform: translateY(-2px);
+  }
+`;
+
 const PopupRegister = styled.p`
   font-size: 0.9rem;
   text-align: center;
@@ -443,6 +463,7 @@ export default function Navbar() {
                   Hola, {userData?.nombre}
                 </AccessButton>
                 <LoginPopup show={loginOpen}>
+                  <PopupLink to={`/perfil/${user?.uid}`}>Mi Cuenta</PopupLink>
                   <PopupButton onClick={handleLogout}>
                     Cerrar sesión
                   </PopupButton>

--- a/src/firebase/firebaseConfig.js
+++ b/src/firebase/firebaseConfig.js
@@ -5,6 +5,7 @@ import { initializeApp }   from 'firebase/app';
 import { getAnalytics }    from 'firebase/analytics';
 import { getAuth }         from 'firebase/auth';
 import { getFirestore }    from 'firebase/firestore';
+import { getStorage }      from 'firebase/storage';
 
 // 2) Tu configuración de Firebase (la misma que ya tenías)
 const firebaseConfig = {
@@ -24,6 +25,7 @@ const app = initializeApp(firebaseConfig);
 const analytics = getAnalytics(app);
 export const auth      = getAuth(app);
 export const db        = getFirestore(app);
+export const storage   = getStorage(app);
 
 // 5) Opcionalmente exporta analytics si lo necesitas en alguna parte
 export { analytics };


### PR DESCRIPTION
## Summary
- add Firebase storage export
- show `Mi Cuenta` menu option in the navbar
- extend profile screen to display user details, allow editing own data and photo upload

## Testing
- `npm install --quiet`
- `npm test --silent` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68438c227cf4832ba818728a939774dd