### PR TITLE
Fix profile photo editing overlay

### DIFF
--- a/src/screens/shared/Perfil.jsx
+++ b/src/screens/shared/Perfil.jsx
@@ -341,8 +341,14 @@ export default function Perfil() {
 
         <ProfileHeader>
           <PhotoWrapper>
-            {profile.photoURL && <Photo src={profile.photoURL} alt="Foto" />}
-            {isOwnProfile && (
+            {profile.photoURL ? (
+              <Photo src={profile.photoURL} alt="Foto" />
+            ) : (
+              (!isOwnProfile || !isEditing) && (
+                <CameraOverlay src={cameraIcon} hasPhoto={false} />
+              )
+            )}
+            {isOwnProfile && isEditing && (
               <>
                 <HiddenFileInput
                   id="photo-input"
@@ -356,9 +362,6 @@ export default function Perfil() {
                   />
                 </PhotoLabel>
               </>
-            )}
-            {!profile.photoURL && !isOwnProfile && (
-              <CameraOverlay src={cameraIcon} hasPhoto={false} />
             )}
           </PhotoWrapper>
           <div>


### PR DESCRIPTION
## Summary
- only show camera overlay in edit mode in `Perfil`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439808a8f8832b8c82d738cb88762c