### PR TITLE
Fix ESLint warnings for Calendario components

### DIFF
--- a/src/screens/alumno/acciones/Calendario.jsx
+++ b/src/screens/alumno/acciones/Calendario.jsx
@@ -12,9 +12,7 @@ import {
   format,
   isSameMonth,
   isSameDay,
-  parseISO,
-  getDay,
-  eachDayOfInterval
+  parseISO
 } from 'date-fns';
 import { es } from 'date-fns/locale';
 

--- a/src/screens/profesor/acciones/Calendario.jsx
+++ b/src/screens/profesor/acciones/Calendario.jsx
@@ -11,9 +11,7 @@ import {
   format,
   isSameMonth,
   isSameDay,
-  parseISO,
-  getDay,
-  eachDayOfInterval
+  parseISO
 } from 'date-fns';
 import { es } from 'date-fns/locale';
 
@@ -114,16 +112,6 @@ const EventItem = styled.div`
   line-height: 1.2;
 `;
 
-// Mapeo de días para recurrentes
-const dayNameToNum = {
-  'Domingo': 0,
-  'Lunes':   1,
-  'Martes':  2,
-  'Miércoles': 3,
-  'Jueves':  4,
-  'Viernes': 5,
-  'Sábado':  6
-};
 
 export default function CalendarioProfesor() {
   const [currentMonth, setCurrentMonth] = useState(new Date());
@@ -132,8 +120,6 @@ export default function CalendarioProfesor() {
 
   useEffect(() => {
     (async () => {
-      const uSnap = await getDoc(doc(db, 'usuarios', auth.currentUser.uid));
-      const nombre = uSnap.exists() ? `${uSnap.data().nombre} ${uSnap.data().apellidos || ''}`.trim() : '';
       const q = query(
         collection(db, 'clases_union'),
         where('profesorId', '==', auth.currentUser.uid)


### PR DESCRIPTION
## Summary
- remove unused imports in Calendario components
- drop unused day name mapping and name lookup in profesor calendar

## Testing
- `CI=true npm test --silent` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68441b52e884832b9d23fdc1eee2d3c8