### PR TITLE
Reset new class form after submission

### DIFF
--- a/src/screens/alumno/acciones/NuevaClase.jsx
+++ b/src/screens/alumno/acciones/NuevaClase.jsx
@@ -453,6 +453,24 @@ export default function NuevaClase() {
     setConfirmModal(true);
   };
 
+  // Restablecer todos los campos del formulario
+  const resetForm = () => {
+    setAsignatura('');
+    setCurso('');
+    setTipoClase('individual');
+    setModalidad('online');
+    setCiudad('');
+    setZona('');
+    setStartDate('');
+    setEndDate('');
+    setNoEndDate(false);
+    setHorasSemana('');
+    setNotas('');
+    setPrecioPadres(0);
+    setPrecioProfesores(0);
+    setSelectedSlots(new Set());
+  };
+
   // Confirmar y guardar
   const confirmRequest = async () => {
     if (submitting) return;
@@ -479,6 +497,7 @@ export default function NuevaClase() {
         createdAt: serverTimestamp()
       });
       show('Clase solicitada con éxito');
+      resetForm();
       setConfirmModal(false);
       navigate('/alumno?tab=calendario');
     } catch (err) {


### PR DESCRIPTION
## Summary
- add resetForm helper in `NuevaClase`
- reset state after creating a class

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845fa0d1bd8832baef3144ed527c1d2