### PR TITLE
Fix menu placement in student panels

### DIFF
--- a/src/screens/alumno/PanelAlumno.jsx
+++ b/src/screens/alumno/PanelAlumno.jsx
@@ -30,7 +30,6 @@ const Sidebar = styled.nav`
   box-shadow: 2px 0 6px rgba(0,0,0,0.05);
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
   overflow-y: auto;
 `;
 
@@ -68,7 +67,8 @@ const Button = styled.button`
 `;
 
 const ChildSelect = styled.div`
-  margin-top: 1rem;
+  margin-top: auto;
+  padding-top: 1rem;
   label {
     display: block;
     margin-bottom: 0.25rem;


### PR DESCRIPTION
## Summary
- adjust sidebar layout in student panel so action list starts just below the role title

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6846086294f8832bb7f992413bd8b672