### PR TITLE
Add alert after sending offer

### DIFF
--- a/src/screens/profesor/acciones/Ofertas.jsx
+++ b/src/screens/profesor/acciones/Ofertas.jsx
@@ -559,6 +559,13 @@ export default function Ofertas() {
     setSelected(null);
     setSelectedSlots(new Set());
 
+    // Aviso de proceso de selección
+    window.alert(
+      'Has entrado en el proceso de selección de esta clase. ' +
+      'Aún no has sido seleccionado, pero si los administradores deciden asignarte ' +
+      'recibirás un correo en la dirección con la que te registraste.'
+    );
+
     // Construir el texto de notificación
     const inicioTxt = clase.fechaInicio ? formatSpanishDate(new Date(clase.fechaInicio)) : '—';
     const finTxt = clase.fechaFin ? formatSpanishDate(new Date(clase.fechaFin)) : '—';


### PR DESCRIPTION
## Summary
- show informational alert after submitting an offer

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68460c31a0fc832ba5b0c062594d9453