### PR TITLE
Add modal for offer selection notice

### DIFF
--- a/src/screens/profesor/acciones/Ofertas.jsx
+++ b/src/screens/profesor/acciones/Ofertas.jsx
@@ -411,6 +411,7 @@ export default function Ofertas() {
   const [selected, setSelected] = useState(null);
   const [selectedSlots, setSelectedSlots] = useState(new Set());
   const [confirmModal, setConfirmModal] = useState(false);
+  const [infoModal, setInfoModal] = useState(false);
 
   // Notificaciones
   const [successNotification, setSuccessNotification] = useState('');
@@ -559,12 +560,8 @@ export default function Ofertas() {
     setSelected(null);
     setSelectedSlots(new Set());
 
-    // Aviso de proceso de selección
-    window.alert(
-      'Has entrado en el proceso de selección de esta clase. ' +
-      'Aún no has sido seleccionado, pero si los administradores deciden asignarte ' +
-      'recibirás un correo en la dirección con la que te registraste.'
-    );
+    // Mostrar información de proceso de selección en un modal
+    setInfoModal(true);
 
     // Construir el texto de notificación
     const inicioTxt = clase.fechaInicio ? formatSpanishDate(new Date(clase.fechaInicio)) : '—';
@@ -895,6 +892,24 @@ export default function Ofertas() {
                 </ModalButton>
                 <ModalButton primary onClick={confirmRequest}>
                   Confirmar oferta
+                </ModalButton>
+              </ModalActions>
+            </Modal>
+          </Overlay>
+        )}
+
+        {/* Modal informativo tras enviar oferta */}
+        {infoModal && (
+          <Overlay>
+            <Modal>
+              <ModalText>
+                Has entrado en el proceso de selección de esta clase.<br/>
+                Aún no has sido seleccionado, pero si los administradores deciden asignarte
+                recibirás un correo en la dirección con la que te registraste.
+              </ModalText>
+              <ModalActions>
+                <ModalButton primary onClick={() => setInfoModal(false)}>
+                  Entendido
                 </ModalButton>
               </ModalActions>
             </Modal>


### PR DESCRIPTION
## Summary
- notify teachers about the selection process using an in-app modal instead of `window.alert`

## Testing
- `npm install`
- `CI=true npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68460e2dc5e4832bba104200fdcc2bce