### PR TITLE
Add level progression system

### DIFF
--- a/src/screens/shared/Perfil.jsx
+++ b/src/screens/shared/Perfil.jsx
@@ -15,6 +15,7 @@ import {
 } from 'firebase/firestore';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import cameraIcon from '../../assets/icons/camara.png';
+import { getProgressData, getRoleTitle, levelThresholds } from '../../utils/levels';
 import {
   BarChart,
   Bar,
@@ -151,6 +152,31 @@ const TextInput = styled.input`
   border-radius: 4px;
 `;
 
+const ProgressWrapper = styled.div`
+  margin-bottom: 2rem;
+`;
+
+const ProgressLabel = styled.div`
+  font-weight: 600;
+  color: #014F40;
+  margin-bottom: 0.25rem;
+`;
+
+const ProgressBarBackground = styled.div`
+  width: 100%;
+  height: 16px;
+  background: #e6e8eb;
+  border-radius: 8px;
+  overflow: hidden;
+`;
+
+const ProgressBarFill = styled.div`
+  height: 100%;
+  background: #02c37e;
+  width: ${({ percent }) => percent}%;
+  transition: width 0.3s ease;
+`;
+
 const ChartContainer = styled.div`
   width: 100%;
   height: 300px;
@@ -174,6 +200,8 @@ export default function Perfil() {
   const [chartData, setChartData] = useState([]); // datos para gráficas mensuales
 
   const isOwnProfile = auth.currentUser && auth.currentUser.uid === userId;
+  const progressInfo = getProgressData(metrics.totalClases);
+  const levelName = getRoleTitle(role, progressInfo.level);
 
   const handleSave = async () => {
     await updateDoc(doc(db, 'usuarios', userId), {
@@ -418,6 +446,18 @@ export default function Perfil() {
             )}
           </div>
         </ProfileHeader>
+
+        <ProgressWrapper>
+          <ProgressLabel>
+            Nivel {progressInfo.level} - {levelName}
+          </ProgressLabel>
+          <ProgressBarBackground>
+            <ProgressBarFill percent={progressInfo.progress} />
+          </ProgressBarBackground>
+          <div style={{ fontSize: '0.85rem', color: '#666', marginTop: '0.25rem' }}>
+            {metrics.totalClases}/{levelThresholds[levelThresholds.length - 1]} clases
+          </div>
+        </ProgressWrapper>
 
         {/* Métricas generales */}
         <Section>

--- a/src/utils/levels.js
+++ b/src/utils/levels.js
@@ -1,0 +1,50 @@
+export const levelThresholds = [0, 1, 4, 12, 25, 45, 70, 100, 135, 170, 200];
+
+export function getLevelFromClasses(classes) {
+  for (let i = levelThresholds.length - 1; i >= 0; i--) {
+    if (classes >= levelThresholds[i]) {
+      return i;
+    }
+  }
+  return 0;
+}
+
+export function getRoleTitle(role, level) {
+  const profTitles = [
+    'Sin experiencia',
+    'Profe Novato',
+    'Profe Aprendiz',
+    'Profe en Marcha',
+    'Profe Avanzado',
+    'Profe Entusiasta',
+    'Profe Hábil',
+    'Profe Destacado',
+    'Profe Admirado',
+    'Profe Veterano',
+    'Profesor Experto'
+  ];
+  const alumnoTitles = [
+    'Nuevo',
+    'Alumno Novato',
+    'Alumno en Progreso',
+    'Alumno Persistente',
+    'Alumno Constante',
+    'Alumno Avanzado',
+    'Alumno Dedicado',
+    'Alumno Estrella',
+    'Alumno Destacado',
+    'Alumno Ejemplar',
+    'Alumno Experto'
+  ];
+  const titles = role === 'profesor' ? profTitles : alumnoTitles;
+  return titles[level] || titles[titles.length - 1];
+}
+
+export function getProgressData(classes) {
+  const level = getLevelFromClasses(classes);
+  const prev = levelThresholds[level];
+  const next = levelThresholds[level + 1] ?? levelThresholds[level];
+  const range = next - prev || 1;
+  const progress = Math.min(100, ((classes - prev) / range) * 100);
+  return { level, progress, next };
+}


### PR DESCRIPTION
## Summary
- implement level calculation utilities
- show progress bar and level info on Profile screen

## Testing
- `npm test --silent -- -w=0 --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b0fd5ed48832b92234214b99e8e70