### PR TITLE
Add animated loading screen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 // src/App.js
-import React from 'react';
-import { BrowserRouter, Routes, Route, Navigate, Outlet } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { BrowserRouter, Routes, Route, Navigate, Outlet, useLocation } from 'react-router-dom';
 import RequireAuth from './components/RequireAuth';
 import RedirectLoggedIn from './components/RedirectLoggedIn';
 import styled from 'styled-components';
@@ -30,6 +30,7 @@ import GestionClases   from './screens/admin/acciones/GestionClases';
 import MisProfesores   from './screens/alumno/acciones/MisProfesores';
 import MisAlumnos      from './screens/profesor/acciones/MisAlumnos';
 import Perfil          from './screens/shared/Perfil';
+import LoadingScreen   from './components/LoadingScreen';
 
 const AppContainer = styled.div`
   display: flex;
@@ -49,12 +50,20 @@ const Layout = () => (
   </>
 );
 
-export default function App() {
+function AppContent() {
+  const location = useLocation();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    const timer = setTimeout(() => setLoading(false), 800);
+    return () => clearTimeout(timer);
+  }, [location]);
+
   return (
-    <BrowserRouter>
-      <ScrollToTop />
-      <AppContainer>
-        <Routes>
+    <AppContainer>
+      {loading && <LoadingScreen />}
+      <Routes>
           {/* Sin Navbar/Footer */}
           <Route path="/alta-profesor" element={<SignUpProfesor />} />
           <Route path="/alta-alumno"   element={<SignUpAlumno />} />
@@ -98,10 +107,18 @@ export default function App() {
               <Route path="/alta"                 element={<Alta />} />
 
             {/* Cualquier otra ruta redirige a /home */}
-            <Route path="*" element={<Navigate to="/home" replace />} />
-          </Route>
-        </Routes>
-      </AppContainer>
+          <Route path="*" element={<Navigate to="/home" replace />} />
+        </Route>
+      </Routes>
+    </AppContainer>
+  );
+}
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <ScrollToTop />
+      <AppContent />
     </BrowserRouter>
   );
 }

--- a/src/components/LoadingScreen.jsx
+++ b/src/components/LoadingScreen.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import styled, { keyframes } from 'styled-components';
+import logo from '../assets/logo-sin-fondo.png';
+
+const pulse = keyframes`
+  0%, 100% { opacity: 0.6; transform: scale(0.9); }
+  50% { opacity: 1; transform: scale(1.1); }
+`;
+
+const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: ${({ theme }) => theme.colors.background};
+  z-index: 2000;
+`;
+
+const Logo = styled.img`
+  width: 150px;
+  animation: ${pulse} 1.6s ease-in-out infinite;
+`;
+
+export default function LoadingScreen() {
+  return (
+    <Overlay>
+      <Logo src={logo} alt="Cargando..." />
+    </Overlay>
+  );
+}


### PR DESCRIPTION
## Summary
- create `LoadingScreen` component with fade/scale animation
- integrate `LoadingScreen` globally via `AppContent` in `App.js`
- show loading overlay for a short time on route changes

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c33919f20832ba70293e69281d23b