### PR TITLE
Improve loading screen behavior

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -62,7 +62,7 @@ function AppContent() {
 
   return (
     <AppContainer>
-      {loading && <LoadingScreen />}
+      {loading && <LoadingScreen fullscreen />}
       <Routes>
           {/* Sin Navbar/Footer */}
           <Route path="/alta-profesor" element={<SignUpProfesor />} />

--- a/src/components/LoadingScreen.jsx
+++ b/src/components/LoadingScreen.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled, { keyframes } from 'styled-components';
-import logo from '../assets/logo-sin-fondo.png';
+import logo from '../assets/logo-sin-fondo-negro.png';
 
 const pulse = keyframes`
   0%, 100% { opacity: 0.6; transform: scale(0.9); }
@@ -8,11 +8,11 @@ const pulse = keyframes`
 `;
 
 const Overlay = styled.div`
-  position: fixed;
+  position: ${({ fullscreen }) => (fullscreen ? 'fixed' : 'absolute')};
   top: 0;
   left: 0;
   width: 100%;
-  height: 100%;
+  height: ${({ fullscreen }) => (fullscreen ? '100vh' : '100%')};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -25,9 +25,9 @@ const Logo = styled.img`
   animation: ${pulse} 1.6s ease-in-out infinite;
 `;
 
-export default function LoadingScreen() {
+export default function LoadingScreen({ fullscreen = false, ...rest }) {
   return (
-    <Overlay>
+    <Overlay fullscreen={fullscreen} {...rest}>
       <Logo src={logo} alt="Cargando..." />
     </Overlay>
   );


### PR DESCRIPTION
## Summary
- update loading screen image
- allow loading screen to cover only its container
- use fullscreen prop for top level loading screen

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c463c52d4832ba895dadc51114b6b