### PR TITLE
Fix loading screen z-index

### DIFF
--- a/src/components/LoadingScreen.jsx
+++ b/src/components/LoadingScreen.jsx
@@ -17,7 +17,8 @@ const Overlay = styled.div`
   align-items: center;
   justify-content: center;
   background-color: ${({ theme }) => theme.colors.background};
-  z-index: 2000;
+  /* Mantener la pantalla de carga por debajo de la navbar y paneles */
+  z-index: 500;
 `;
 
 const Logo = styled.img`

--- a/src/screens/admin/PanelAdmin.jsx
+++ b/src/screens/admin/PanelAdmin.jsx
@@ -24,6 +24,8 @@ const Sidebar = styled.nav`
   padding: 2rem 1rem;
   box-shadow: 2px 0 6px rgba(0,0,0,0.05);
   overflow-y: auto;         /* por si el menú es más largo que la pantalla */
+  /* Mantener el panel por encima de la pantalla de carga */
+  z-index: 1000;
 `;
 
 const Logo = styled.h1`

--- a/src/screens/alumno/PanelAlumno.jsx
+++ b/src/screens/alumno/PanelAlumno.jsx
@@ -31,6 +31,8 @@ const Sidebar = styled.nav`
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  /* Mantener el panel por encima de la pantalla de carga */
+  z-index: 1000;
 `;
 
 const Logo = styled.h1`

--- a/src/screens/profesor/PanelProfesor.jsx
+++ b/src/screens/profesor/PanelProfesor.jsx
@@ -25,6 +25,8 @@ const Sidebar = styled.nav`
   padding: 2rem 1rem;
   box-shadow: 2px 0 6px rgba(0,0,0,0.05);
   overflow-y: auto;
+  /* Mantener el panel por encima de la pantalla de carga */
+  z-index: 1000;
 `;
 
 const Logo = styled.h1`


### PR DESCRIPTION
## Summary
- ensure the loading screen stays below the navigation bar and role panels
- keep admin, professor and student sidebars above any loading overlay

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c48effbb4832b9e2d553a7d462047