### PR TITLE
Improve login error handling

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -13,6 +13,7 @@ import {
   signOut,
   signInWithEmailAndPassword
 } from 'firebase/auth';
+import { getAuthErrorMessage } from '../utils/authErrorMessages';
 import { doc, getDoc } from 'firebase/firestore';
 import { useNotification } from '../NotificationContext';
 
@@ -401,7 +402,7 @@ export default function Navbar() {
       setLoginPassword('');
       setLoginOpen(false);
     } catch (err) {
-      show(`Error al iniciar sesión: ${err.message}`);
+      show(getAuthErrorMessage(err.code));
     } finally {
       setLoggingIn(false);
     }

--- a/src/screens/InicioSesion.jsx
+++ b/src/screens/InicioSesion.jsx
@@ -14,6 +14,7 @@ import {
   GoogleAuthProvider,
   OAuthProvider
 } from 'firebase/auth';
+import { getAuthErrorMessage } from '../utils/authErrorMessages';
 
 const PageWrapper = styled.div`
   min-height: 100vh;
@@ -182,7 +183,7 @@ const InicioSesion = () => {
       await signInWithEmailAndPassword(auth, email, password);
       navigate('/home');
     } catch (err) {
-      setError(err.message);
+      setError(getAuthErrorMessage(err.code));
     }
     setLoading(false);
   };
@@ -194,7 +195,7 @@ const InicioSesion = () => {
       await signInWithPopup(auth, googleProvider);
       navigate('/home');
     } catch (err) {
-      setError(err.message);
+      setError(getAuthErrorMessage(err.code));
     }
     setLoading(false);
   };
@@ -206,7 +207,7 @@ const InicioSesion = () => {
       await signInWithPopup(auth, appleProvider);
       navigate('/home');
     } catch (err) {
-      setError(err.message);
+      setError(getAuthErrorMessage(err.code));
     }
     setLoading(false);
   };

--- a/src/utils/authErrorMessages.js
+++ b/src/utils/authErrorMessages.js
@@ -1,0 +1,9 @@
+export function getAuthErrorMessage(code) {
+  const map = {
+    'auth/user-not-found': 'El correo electrónico no existe.',
+    'auth/wrong-password': 'La contraseña es incorrecta.',
+    'auth/invalid-email': 'El correo electrónico no es válido.',
+    'auth/too-many-requests': 'Demasiados intentos. Intenta más tarde.'
+  };
+  return map[code] || 'Error al iniciar sesión';
+}


### PR DESCRIPTION
## Summary
- map Firebase auth codes to Spanish strings
- show friendly login messages in InicioSesion screen
- show friendly login messages in Navbar popup

## Testing
- `npm test -- -w 0 --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684c632035d0832bae1b5754521420ff