### PR TITLE
Enable Google login with role selection

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -31,6 +31,7 @@ import MisProfesores   from './screens/alumno/acciones/MisProfesores';
 import MisAlumnos      from './screens/profesor/acciones/MisAlumnos';
 import Perfil          from './screens/shared/Perfil';
 import LoadingScreen   from './components/LoadingScreen';
+import SeleccionRol    from './screens/SeleccionRol';
 
 const AppContainer = styled.div`
   display: flex;
@@ -68,6 +69,7 @@ function AppContent() {
           <Route path="/alta-profesor" element={<SignUpProfesor />} />
           <Route path="/alta-alumno"   element={<SignUpAlumno />} />
           <Route path="/inicio"        element={<InicioSesion />} />
+          <Route path="/seleccion-rol" element={<SeleccionRol />} />
 
           {/* Con Navbar/Footer */}
           <Route element={<Layout />}>

--- a/src/screens/InicioSesion.jsx
+++ b/src/screens/InicioSesion.jsx
@@ -7,13 +7,14 @@ import googleLogo from '../assets/google.png';
 import appleLogo from '../assets/apple.png';
 
 // Firebase
-import { auth } from '../firebase/firebaseConfig';
+import { auth, db } from '../firebase/firebaseConfig';
 import {
   signInWithEmailAndPassword,
   signInWithPopup,
   GoogleAuthProvider,
   OAuthProvider
 } from 'firebase/auth';
+import { doc, getDoc } from 'firebase/firestore';
 import { getAuthErrorMessage } from '../utils/authErrorMessages';
 
 const PageWrapper = styled.div`
@@ -192,8 +193,13 @@ const InicioSesion = () => {
     setError('');
     setLoading(true);
     try {
-      await signInWithPopup(auth, googleProvider);
-      navigate('/home');
+      const { user } = await signInWithPopup(auth, googleProvider);
+      const snap = await getDoc(doc(db, 'usuarios', user.uid));
+      if (snap.exists()) {
+        navigate('/home');
+      } else {
+        navigate('/seleccion-rol');
+      }
     } catch (err) {
       setError(getAuthErrorMessage(err.code));
     }

--- a/src/screens/SeleccionRol.jsx
+++ b/src/screens/SeleccionRol.jsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../AuthContext';
+import { useNotification } from '../NotificationContext';
+import { db } from '../firebase/firebaseConfig';
+import { doc, setDoc } from 'firebase/firestore';
+
+const Page = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #f9fdfc 0%, #dff8f2 100%);
+`;
+
+const Card = styled.div`
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 14px 36px rgba(0,0,0,0.15);
+  padding: 3rem 2rem;
+  width: 100%;
+  max-width: 420px;
+  text-align: center;
+`;
+
+const Title = styled.h2`
+  color: #034640;
+  margin-bottom: 2rem;
+`;
+
+const ButtonGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+const Button = styled.button`
+  padding: 0.75rem 1rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: #046654;
+  color: #fff;
+  transition: background 0.3s;
+  &:hover {
+    background: #034640;
+  }
+`;
+
+export default function SeleccionRol() {
+  const { user } = useAuth();
+  const { show } = useNotification();
+  const navigate = useNavigate();
+
+  const handleSelect = async rol => {
+    if (!user) return;
+    try {
+      const [nombre, ...apellidos] = user.displayName ? user.displayName.split(' ') : ['', ''];
+      await setDoc(doc(db, 'usuarios', user.uid), {
+        uid: user.uid,
+        email: user.email,
+        nombre,
+        apellido: apellidos.join(' '),
+        rol,
+        createdAt: new Date()
+      });
+      navigate('/home');
+    } catch (err) {
+      console.error(err);
+      show('Error al guardar datos');
+    }
+  };
+
+  return (
+    <Page>
+      <Card>
+        <Title>Selecciona tu rol</Title>
+        <ButtonGroup>
+          <Button onClick={() => handleSelect('alumno')}>Alumno</Button>
+          <Button onClick={() => handleSelect('padre')}>Padre</Button>
+          <Button onClick={() => handleSelect('profesor')}>Profesor</Button>
+        </ButtonGroup>
+      </Card>
+    </Page>
+  );
+}


### PR DESCRIPTION
## Summary
- add intermediate role selection screen
- store role for Google signups
- route to new screen when a Google user has no profile

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9fb0a60c832bb2b689ecad78b447