### PR TITLE
Fix login error message for navbar

### DIFF
--- a/src/utils/authErrorMessages.js
+++ b/src/utils/authErrorMessages.js
@@ -1,7 +1,7 @@
 export function getAuthErrorMessage(code) {
   const map = {
-    'auth/user-not-found': 'El correo electrónico no existe.',
-    'auth/wrong-password': 'La contraseña es incorrecta.',
+    'auth/user-not-found': 'Correo o contraseña incorrecto.',
+    'auth/wrong-password': 'Correo o contraseña incorrecto.',
     'auth/invalid-email': 'El correo electrónico no es válido.',
     'auth/too-many-requests': 'Demasiados intentos. Intenta más tarde.'
   };


### PR DESCRIPTION
## Summary
- show generic message when login credentials are wrong

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684da3ba3278832b8976f4ceeec96a2f