### PR TITLE
Add password reset popup

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -5,6 +5,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import logo from '../assets/logonavbar.png';
 import googleLogo from '../assets/google.png';
 import appleLogo from '../assets/apple.png';
+import PasswordResetModal from './PasswordResetModal';
 
 // Firebase
 import { auth, db } from '../firebase/firebaseConfig';
@@ -265,6 +266,16 @@ const PopupButton = styled.button`
   }
 `;
 
+const PopupForgot = styled.button`
+  background: none;
+  border: none;
+  color: #1e90ff;
+  cursor: pointer;
+  font-size: 0.85rem;
+  text-decoration: underline;
+  margin-bottom: 0.75rem;
+`;
+
 const PopupLink = styled(Link)`
   display: block;
   color: #fff;
@@ -356,6 +367,7 @@ export default function Navbar() {
   const [loginError, setLoginError] = useState('');
   const [loginOpen, setLoginOpen] = useState(false);
   const [loggingIn, setLoggingIn] = useState(false);
+  const [resetOpen, setResetOpen] = useState(false);
   const loginRef = useRef(null);
   const navigate = useNavigate();
 
@@ -464,6 +476,7 @@ export default function Navbar() {
       : 'Panel Alumno/a';
 
   return (
+    <>
     <Nav>
       <Container>
         {user ? (
@@ -537,6 +550,9 @@ export default function Navbar() {
                   <PopupButton onClick={handleLogin} disabled={loggingIn}>
                     Iniciar sesión
                   </PopupButton>
+                  <PopupForgot onClick={() => { setLoginOpen(false); setResetOpen(true); }}>
+                    ¿Has olvidado la contraseña?
+                  </PopupForgot>
                   <PopupRegister>
                     ¿No tienes cuenta? <Link to="/alta">Regístrate</Link>
                   </PopupRegister>
@@ -569,5 +585,7 @@ export default function Navbar() {
         </Menu>
       </Container>
     </Nav>
+    <PasswordResetModal open={resetOpen} onClose={() => setResetOpen(false)} />
+    </>
   );
 }

--- a/src/components/PasswordResetModal.jsx
+++ b/src/components/PasswordResetModal.jsx
@@ -1,0 +1,134 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { sendPasswordResetEmail } from 'firebase/auth';
+import { auth } from '../firebase/firebaseConfig';
+import { getAuthErrorMessage } from '../utils/authErrorMessages';
+import logo from '../assets/logonavbar.png';
+
+const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1500;
+`;
+
+const Modal = styled.div`
+  background: #fff;
+  border-radius: 10px;
+  padding: 2rem 1.5rem;
+  width: 100%;
+  max-width: 420px;
+  text-align: center;
+  box-shadow: 0 12px 36px rgba(0,0,0,0.2);
+  position: relative;
+`;
+
+const CloseButton = styled.button`
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  cursor: pointer;
+`;
+
+const Logo = styled.img`
+  width: 120px;
+  margin: 0 auto 1rem;
+`;
+
+const Title = styled.h2`
+  margin: 0 0 1rem;
+  color: #014F40;
+`;
+
+const Input = styled.input`
+  width: 100%;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 1rem;
+`;
+
+const Button = styled.button`
+  width: 100%;
+  background: #ccf3e5;
+  color: #034640;
+  padding: 0.75rem 1rem;
+  border: none;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  opacity: ${p => (p.disabled ? 0.6 : 1)};
+`;
+
+const ErrorText = styled.p`
+  color: #ff6b6b;
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+`;
+
+const SuccessText = styled.p`
+  color: #02b36e;
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+`;
+
+export default function PasswordResetModal({ open, onClose }) {
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [sending, setSending] = useState(false);
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    setError('');
+    setSuccess('');
+    setSending(true);
+    try {
+      await sendPasswordResetEmail(auth, email, { url: window.location.origin + '/inicio' });
+      setSuccess('Hemos enviado un correo para restablecer tu contraseña.');
+      setEmail('');
+    } catch (err) {
+      setError(getAuthErrorMessage(err.code));
+    } finally {
+      setSending(false);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <Overlay>
+      <Modal>
+        <CloseButton onClick={onClose}>✕</CloseButton>
+        <Logo src={logo} alt="Student Project" />
+        <Title>Restablecer contraseña</Title>
+        {error && <ErrorText>{error}</ErrorText>}
+        {success && <SuccessText>{success}</SuccessText>}
+        <form onSubmit={handleSubmit}>
+          <Input
+            type="email"
+            placeholder="Tu correo electrónico"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
+          />
+          <Button type="submit" disabled={sending}>
+            {sending ? 'Enviando...' : 'Enviar'}
+          </Button>
+        </form>
+      </Modal>
+    </Overlay>
+  );
+}
+

--- a/src/screens/InicioSesion.jsx
+++ b/src/screens/InicioSesion.jsx
@@ -5,6 +5,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import logo from '../assets/logo-fondo.jpg';
 import googleLogo from '../assets/google.png';
 import appleLogo from '../assets/apple.png';
+import PasswordResetModal from '../components/PasswordResetModal';
 
 // Firebase
 import { auth, db } from '../firebase/firebaseConfig';
@@ -80,6 +81,16 @@ const Button = styled.button`
     opacity: 0.6;
     cursor: default;
   }
+`;
+
+const ForgotLink = styled.button`
+  background: none;
+  border: none;
+  color: #1e90ff;
+  cursor: pointer;
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+  text-decoration: underline;
 `;
 
 const RegisterText = styled.p`
@@ -171,6 +182,7 @@ const InicioSesion = () => {
   const [password, setPassword]   = useState('');
   const [error, setError]         = useState('');
   const [loading, setLoading]     = useState(false);
+  const [resetOpen, setResetOpen] = useState(false);
 
   // Providers
   const googleProvider = new GoogleAuthProvider();
@@ -246,6 +258,9 @@ const InicioSesion = () => {
           <Button type="submit" disabled={loading}>
             {loading ? 'Cargando...' : 'Iniciar sesión'}
           </Button>
+          <ForgotLink type="button" onClick={() => setResetOpen(true)}>
+            ¿Has olvidado la contraseña?
+          </ForgotLink>
         </Form>
 
         <RegisterText>
@@ -271,6 +286,7 @@ const InicioSesion = () => {
           <Link to="/politica-y-privacidad">Política de Privacidad</Link>.
         </InfoText>
       </Card>
+      <PasswordResetModal open={resetOpen} onClose={() => setResetOpen(false)} />
     </PageWrapper>
   );
 };

--- a/src/utils/authErrorMessages.js
+++ b/src/utils/authErrorMessages.js
@@ -1,9 +1,10 @@
 export function getAuthErrorMessage(code) {
   const map = {
-    'auth/user-not-found': 'Correo o contraseña incorrecto.',
+    'auth/user-not-found': 'Correo no registrado.',
     'auth/wrong-password': 'Correo o contraseña incorrecto.',
     'auth/invalid-email': 'El correo electrónico no es válido.',
-    'auth/too-many-requests': 'Demasiados intentos. Intenta más tarde.'
+    'auth/too-many-requests': 'Demasiados intentos. Intenta más tarde.',
+    'auth/missing-email': 'Debes introducir un correo electrónico.'
   };
-  return map[code] || 'Error al iniciar sesión';
+  return map[code] || 'Se produjo un error. Inténtalo de nuevo.';
 }


### PR DESCRIPTION
## Summary
- add styled PasswordResetModal component
- offer a reset password link in `InicioSesion`
- expose password reset link in navbar login popup
- extend auth error messages for reset cases

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685082b17c50832b9a7bf8bf02790040