### PR TITLE
Improve forgot password link style

### DIFF
--- a/src/screens/InicioSesion.jsx
+++ b/src/screens/InicioSesion.jsx
@@ -90,7 +90,10 @@ const ForgotLink = styled.button`
   cursor: pointer;
   font-size: 0.9rem;
   margin-top: 0.5rem;
+  width: 100%;
+  text-align: center;
   text-decoration: underline;
+  display: block;
 `;
 
 const RegisterText = styled.p`


### PR DESCRIPTION
## Summary
- ensure "¿Has olvidado la contraseña?" fills the card width and centers like the register link

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685089c7c4fc832ba428f1c7207bb88d