### PR TITLE
Add admin confirmation modal and email placeholder

### DIFF
--- a/src/utils/email.js
+++ b/src/utils/email.js
@@ -1,0 +1,12 @@
+export async function sendAssignmentEmails({ teacherEmail, teacherName, studentEmail, studentName, schedule }) {
+  const payload = { teacherEmail, teacherName, studentEmail, studentName, schedule };
+  try {
+    await fetch(process.env.REACT_APP_EMAIL_API || '/api/send-assignment-email', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+  } catch (err) {
+    console.error('Failed to send emails', err);
+  }
+}


### PR DESCRIPTION
## Summary
- add placeholder `sendAssignmentEmails` helper
- add confirmation modal for accepting teacher offers
- call new email helper after accepting an offer

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68542cdbebe8832bbfd1ba36d4b37a86