### PR TITLE
Enhance class pages with photos and course info

### DIFF
--- a/src/screens/profesor/acciones/Clases.jsx
+++ b/src/screens/profesor/acciones/Clases.jsx
@@ -6,7 +6,9 @@ import {
   collection,
   query,
   where,
-  getDocs
+  getDocs,
+  getDoc,
+  doc
 } from 'firebase/firestore';
 
 const fadeIn = keyframes`
@@ -49,6 +51,35 @@ const Field = styled.p`
   & > strong { color: #014f40; }
 `;
 
+const GroupHeader = styled.div`
+  display: flex;
+  align-items: center;
+  margin: 1.5rem 0 0.75rem;
+`;
+
+const Avatar = styled.img`
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  object-fit: cover;
+  margin-right: 0.75rem;
+`;
+
+const InfoGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.5rem 1rem;
+`;
+
+const Label = styled.span`
+  font-weight: 500;
+  color: #014F40;
+`;
+
+const Value = styled.span`
+  color: #333;
+`;
+
 export default function ClasesProfesor() {
   const [groups, setGroups] = useState([]);
 
@@ -59,15 +90,34 @@ export default function ClasesProfesor() {
       let data = [];
       for (const docu of snap.docs) {
         const union = docu.data();
+        let alumnoFoto = '';
+        let alumnoApellido = '';
+        let curso = '';
+        try {
+          const alumSnap = await getDoc(doc(db, 'usuarios', union.alumnoId));
+          if (alumSnap.exists()) {
+            const d = alumSnap.data();
+            alumnoFoto = d.photoURL || '';
+            alumnoApellido = d.apellido || '';
+          }
+          const classSnap = await getDoc(doc(db, 'clases', union.claseId));
+          if (classSnap.exists()) curso = classSnap.data().curso || '';
+        } catch (err) {
+          console.error(err);
+        }
         const subSnap = await getDocs(
           query(
             collection(db, 'clases_union', docu.id, 'clases_asignadas'),
             where('estado', '==', 'aceptada')
           )
         );
-        const clases = subSnap.docs.map(d => ({ id: d.id, ...d.data() }));
+        const clases = subSnap.docs.map(d => ({ id: d.id, curso, ...d.data() }));
         if (clases.length) {
-          data.push({ alumno: `${union.alumnoNombre} ${union.alumnoApellidos || ''}`.trim(), clases });
+          data.push({
+            alumno: `${union.alumnoNombre} ${alumnoApellido}`.trim(),
+            alumnoFoto,
+            clases
+          });
         }
       }
       setGroups(data);
@@ -81,14 +131,32 @@ export default function ClasesProfesor() {
         {groups.length === 0 && <p>No tienes clases aceptadas.</p>}
         {groups.map(g => (
           <div key={g.alumno}>
-            <GroupTitle>{g.alumno}</GroupTitle>
+            <GroupHeader>
+              {g.alumnoFoto && <Avatar src={g.alumnoFoto} alt="Alumno" />}
+              <GroupTitle>{g.alumno}</GroupTitle>
+            </GroupHeader>
             {g.clases.map(c => (
               <Card key={c.id}>
-                <Field><strong>Asignatura:</strong> {c.asignatura}</Field>
-                <Field><strong>Fecha:</strong> {c.fecha} {c.hora}</Field>
-                <Field><strong>Modalidad:</strong> {c.modalidad}</Field>
-                <Field><strong>Duración:</strong> {c.duracion}h</Field>
-                <Field><strong>Ganancia:</strong> €{(c.precioTotalProfesor || 0).toFixed(2)}</Field>
+                <InfoGrid>
+                  <div>
+                    <Label>Asignatura:</Label> <Value>{c.asignatura}</Value>
+                  </div>
+                  <div>
+                    <Label>Curso:</Label> <Value>{c.curso || '-'}</Value>
+                  </div>
+                  <div>
+                    <Label>Fecha:</Label> <Value>{c.fecha} {c.hora}</Value>
+                  </div>
+                  <div>
+                    <Label>Modalidad:</Label> <Value>{c.modalidad}</Value>
+                  </div>
+                  <div>
+                    <Label>Duración:</Label> <Value>{c.duracion}h</Value>
+                  </div>
+                  <div>
+                    <Label>Ganancia:</Label> <Value>€{(c.precioTotalProfesor || 0).toFixed(2)}</Value>
+                  </div>
+                </InfoGrid>
               </Card>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- show teacher photo and course in student class list
- show student photo and course in professor class list

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685446d55f44832b8d1e17be908ff567