### PR TITLE
Add email validation on login and signup

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -19,6 +19,7 @@ import {
 import { getAuthErrorMessage } from '../utils/authErrorMessages';
 import { doc, getDoc, updateDoc, setDoc } from 'firebase/firestore';
 import { useNotification } from '../NotificationContext';
+import { isValidEmail } from '../utils/validateEmail';
 
 const slideDown = keyframes`
   from { opacity: 0; transform: translateY(-10px); }
@@ -406,6 +407,11 @@ export default function Navbar() {
     if (loggingIn) return;
     setLoggingIn(true);
     setLoginError('');
+    if (!isValidEmail(loginEmail)) {
+      setLoginError('Correo electrónico no válido.');
+      setLoggingIn(false);
+      return;
+    }
     try {
       const userCredential = await signInWithEmailAndPassword(auth, loginEmail, loginPassword);
       const u = userCredential.user;
@@ -539,7 +545,10 @@ export default function Navbar() {
                     type="email"
                     placeholder="Correo electrónico"
                     value={loginEmail}
-                    onChange={e => setLoginEmail(e.target.value)}
+                    onChange={e => {
+                      setLoginEmail(e.target.value);
+                      setLoginError('');
+                    }}
                   />
                   <PopupInput
                     type="password"

--- a/src/screens/InicioSesion.jsx
+++ b/src/screens/InicioSesion.jsx
@@ -17,6 +17,7 @@ import {
 } from 'firebase/auth';
 import { doc, getDoc, updateDoc, setDoc } from 'firebase/firestore';
 import { getAuthErrorMessage } from '../utils/authErrorMessages';
+import { isValidEmail } from '../utils/validateEmail';
 
 const PageWrapper = styled.div`
   min-height: 100vh;
@@ -195,6 +196,11 @@ const InicioSesion = () => {
     e.preventDefault();
     setError('');
     setLoading(true);
+    if (!isValidEmail(email)) {
+      setError('Correo electrónico no válido.');
+      setLoading(false);
+      return;
+    }
     try {
       await signInWithEmailAndPassword(auth, email, password);
       navigate('/home');
@@ -248,7 +254,10 @@ const InicioSesion = () => {
             type="email"
             placeholder="Correo electrónico"
             value={email}
-            onChange={e => setEmail(e.target.value)}
+            onChange={e => {
+              setEmail(e.target.value);
+              setError('');
+            }}
             required
           />
           <Input

--- a/src/screens/SignUpAlumno.jsx
+++ b/src/screens/SignUpAlumno.jsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import styled, { keyframes } from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import { useNotification } from "../NotificationContext";
+import { isValidEmail } from '../utils/validateEmail';
 
 // Firebase (inicializado en firebaseConfig.js)
 import { auth, db } from '../firebase/firebaseConfig';
@@ -67,6 +68,12 @@ const Subtitle = styled.p`
   color: #014F40;
   margin-bottom: 1.5rem;
   font-style: italic;
+`;
+
+const ErrorText = styled.p`
+  color: #ff6b6b;
+  font-size: 0.9rem;
+  margin: 0.25rem 0 0.5rem;
 `;
 
 // Grid/Formato
@@ -257,6 +264,7 @@ const cursosGrouped = [
 
 export default function SignUpAlumno() {
   const [email, setEmail]           = useState('');
+  const [emailError, setEmailError] = useState('');
   const [password, setPassword]     = useState('');
   const [confirmPwd, setConfirmPwd] = useState('');
   const [nombre, setNombre]         = useState('');
@@ -313,6 +321,10 @@ export default function SignUpAlumno() {
       !curso
     ) {
       show('Completa todos los campos');
+      return;
+    }
+    if (!isValidEmail(email)) {
+      setEmailError('Correo electrónico no válido.');
       return;
     }
     if (password !== confirmPwd)
@@ -377,13 +389,17 @@ export default function SignUpAlumno() {
         <FormGrid>
           <Field>
             <label>E-mail</label>
-            <input
-              type="email"
-              value={email}
-              onChange={e => setEmail(e.target.value)}
-              placeholder="tucorreo@ejemplo.com"
-            />
-          </Field>
+          <input
+            type="email"
+            value={email}
+            onChange={e => {
+              setEmail(e.target.value);
+              setEmailError('');
+            }}
+            placeholder="tucorreo@ejemplo.com"
+          />
+          {emailError && <ErrorText>{emailError}</ErrorText>}
+        </Field>
           <Field>
             <label>Contraseña</label>
             <input

--- a/src/screens/SignUpProfesor.jsx
+++ b/src/screens/SignUpProfesor.jsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import styled, { keyframes } from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import { useNotification } from "../NotificationContext";
+import { isValidEmail } from '../utils/validateEmail';
 
 // Firebase (inicializado en firebaseConfig.js)
 import { auth, db } from '../firebase/firebaseConfig';
@@ -70,6 +71,12 @@ const Subtitle = styled.p`
   color: #014F40;
   margin-bottom: 1.8rem;
   font-style: italic;
+`;
+
+const ErrorText = styled.p`
+  color: #ff6b6b;
+  font-size: 0.9rem;
+  margin: 0.25rem 0 0.5rem;
 `;
 
 // Grid para campos
@@ -216,6 +223,7 @@ const ModalButton = styled.button`
 
 export default function SignUpProfesor() {
   const [email, setEmail]             = useState('');
+  const [emailError, setEmailError]   = useState('');
   const [password, setPassword]       = useState('');
   const [confirmPassword, setConfirm] = useState('');
   const [nombre, setNombre]           = useState('');
@@ -259,6 +267,10 @@ export default function SignUpProfesor() {
       show('Completa todos los campos');
       return;
     }
+    if (!isValidEmail(email)) {
+      setEmailError('Correo electrónico no válido.');
+      return;
+    }
     if (password !== confirmPassword) {
       return show('Las contraseñas no coinciden');
     }
@@ -294,13 +306,17 @@ export default function SignUpProfesor() {
         <FormGrid>
           <Field>
             <label>E-mail</label>
-            <input
-              type="email"
-              value={email}
-              onChange={e => setEmail(e.target.value)}
-              placeholder="tucorreo@ejemplo.com"
-            />
-          </Field>
+          <input
+            type="email"
+            value={email}
+            onChange={e => {
+              setEmail(e.target.value);
+              setEmailError('');
+            }}
+            placeholder="tucorreo@ejemplo.com"
+          />
+          {emailError && <ErrorText>{emailError}</ErrorText>}
+        </Field>
           <Field>
             <label>Teléfono</label>
             <input

--- a/src/utils/validateEmail.js
+++ b/src/utils/validateEmail.js
@@ -1,0 +1,8 @@
+export function isValidEmail(email) {
+  if (typeof email !== 'string') return false;
+  const emailRegex = /^[A-Za-z0-9]+(?:\.[A-Za-z0-9]+)*@(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\.)+[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/;
+  if (!emailRegex.test(email)) return false;
+  const [local, domain] = email.split('@');
+  if (!local || !domain) return false;
+  return local.length <= 64 && domain.length <= 255;
+}


### PR DESCRIPTION
## Summary
- validate emails with strict rules
- show error messages when email format is invalid in login forms and signups
- add helper `isValidEmail`

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685598717000832b9eb420789e6c43cf