### PR TITLE
Improve class modification flow

### DIFF
--- a/src/screens/alumno/acciones/Clases.jsx
+++ b/src/screens/alumno/acciones/Clases.jsx
@@ -57,10 +57,6 @@ const Card = styled.div`
   }
 `;
 
-const Field = styled.div`
-  margin-bottom: 0.25rem;
-  & > strong { color: #014f40; }
-`;
 
 const CardHeader = styled.div`
   display: flex;

--- a/src/screens/profesor/acciones/Calendario.jsx
+++ b/src/screens/profesor/acciones/Calendario.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import styled, { keyframes } from 'styled-components';
 import { auth, db } from '../../../firebase/firebaseConfig';
-import { collection, query, where, getDocs, getDoc, doc } from 'firebase/firestore';
+import { collection, query, where, getDocs } from 'firebase/firestore';
 import {
   startOfMonth,
   endOfMonth,

--- a/src/screens/profesor/acciones/Clases.jsx
+++ b/src/screens/profesor/acciones/Clases.jsx
@@ -58,10 +58,6 @@ const Card = styled.div`
   }
 `;
 
-const Field = styled.p`
-  margin: 0.4rem 0;
-  & > strong { color: #014f40; }
-`;
 
 
 const Avatar = styled.img`
@@ -181,6 +177,7 @@ export default function ClasesProfesor() {
   const [editing, setEditing] = useState(null);
   const [newDate, setNewDate] = useState('');
   const [newDuration, setNewDuration] = useState('');
+  const [confirmEdit, setConfirmEdit] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -225,7 +222,7 @@ export default function ClasesProfesor() {
     })();
   }, []);
 
-  const sortedClases = React.useMemo(() => {
+  const sortedClases = useMemo(() => {
     const arr = [...clases];
     arr.sort((a, b) => {
       if (sortBy === 'alumno') {
@@ -250,7 +247,7 @@ export default function ClasesProfesor() {
     const offset = (7 - sunday.getDay()) % 7;
     sunday.setDate(d.getDate() + offset);
     sunday.setHours(16, 0, 0, 0);
-    return Date.now() < sunday.getTime();
+    return !clase.modificacionPendiente && Date.now() < sunday.getTime();
   };
 
   const openEdit = clase => {
@@ -276,7 +273,7 @@ export default function ClasesProfesor() {
     });
     await addDoc(collection(db, 'clases_union', editing.unionId, 'chats'), {
       senderId: auth.currentUser.uid,
-      text: `El profesor propone modificar la clase a ${newDate} (${newDuration}h)`,
+      text: `He modificado la clase del día ${editing.fecha} de duración ${editing.duracion}h a ${newDate} con duración ${newDuration}h`,
       createdAt: serverTimestamp()
     });
     setEditing(null);
@@ -347,7 +344,37 @@ export default function ClasesProfesor() {
             <Input type="number" min="0.5" step="0.5" value={newDuration} onChange={e => setNewDuration(e.target.value)} />
             <ModalActions>
               <ModalButton onClick={() => setEditing(null)}>Cancelar</ModalButton>
-              <ModalButton primary onClick={submitEdit}>Confirmar</ModalButton>
+              <ModalButton
+                primary
+                onClick={() => {
+                  setEditing(null);
+                  setConfirmEdit(true);
+                }}
+              >
+                Confirmar
+              </ModalButton>
+            </ModalActions>
+          </EditModal>
+        </Overlay>
+      )}
+
+      {confirmEdit && (
+        <Overlay onClick={() => setConfirmEdit(false)}>
+          <EditModal onClick={e => e.stopPropagation()}>
+            <p style={{ textAlign: 'center' }}>
+              Solo se puede modificar una sola vez. ¿Confirmar cambio?
+            </p>
+            <ModalActions>
+              <ModalButton onClick={() => setConfirmEdit(false)}>Cancelar</ModalButton>
+              <ModalButton
+                primary
+                onClick={() => {
+                  submitEdit();
+                  setConfirmEdit(false);
+                }}
+              >
+                Confirmar
+              </ModalButton>
             </ModalActions>
           </EditModal>
         </Overlay>


### PR DESCRIPTION
## Summary
- update teacher class editing to require final confirmation
- change chat message when a class is modified
- disable modification if one is already pending
- remove unused styled component `Field`
- fix unused imports in teacher calendar

## Testing
- `npx eslint src --ext js,jsx`
- `npm test -- -w 1`

------
https://chatgpt.com/codex/tasks/task_e_6855a1230664832b940f7cfc379c9316