### PR TITLE
Enable child management for parents

### DIFF
--- a/src/ChildContext.js
+++ b/src/ChildContext.js
@@ -13,10 +13,10 @@ export const ChildProvider = ({ children }) => {
       const hijos = userData.hijos || [];
       setChildList(hijos);
       setSelectedChild(prev => {
-        if (prev && hijos.includes(prev)) {
+        if (prev && hijos.some(h => h.id === prev.id)) {
           return prev;
         }
-        return hijos[0] || null;
+        return null;
       });
     } else {
       setChildList([]);


### PR DESCRIPTION
## Summary
- require explicit child selection before using parent features
- add dropdown placeholder and warnings in parent panel
- allow parents to manage children from their profile

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6855a3d51d64832b8630feefc38ceb05