### PR TITLE
Limit child details in offer and union views

### DIFF
--- a/src/screens/profesor/acciones/MisAlumnos.jsx
+++ b/src/screens/profesor/acciones/MisAlumnos.jsx
@@ -85,10 +85,6 @@ const NameWrapper = styled.div`
   flex-direction: column;
 `;
 
-const ParentText = styled.small`
-  font-size: 0.8rem;
-  color: #555;
-`;
 
 const AddButton = styled.button`
   background: #006D5B;
@@ -524,11 +520,9 @@ export default function MisAlumnos() {
                       navigate(`/perfil/${u.alumnoId}`);
                     }}
                   >
-                    {u.alumnoNombre} {u.alumnoApellidos || ''}
+                    {u.alumnoNombre} {u.alumnoApellidos?.split(' ')[0] || ''}
+                    {u.padreNombre ? ` (${u.padreNombre})` : ''}
                   </NameLink>
-                  {u.padreNombre && (
-                    <ParentText>Padre: {u.padreNombre}</ParentText>
-                  )}
                 </NameWrapper>
                 <AddButton
                   onClick={e => {
@@ -622,7 +616,8 @@ export default function MisAlumnos() {
           <ProposalModal onClick={e => e.stopPropagation()}>
             <ProposalHeader>
               Proponer nueva clase a {selectedUnion.alumnoNombre}{' '}
-              {selectedUnion.alumnoApellidos}
+              {selectedUnion.alumnoApellidos?.split(' ')[0]}
+              {selectedUnion.padreNombre ? ` (${selectedUnion.padreNombre})` : ''}
             </ProposalHeader>
             <Form>
               <Label>Fecha de clase:</Label>

--- a/src/screens/profesor/acciones/Ofertas.jsx
+++ b/src/screens/profesor/acciones/Ofertas.jsx
@@ -568,9 +568,10 @@ export default function Ofertas() {
     const finTxt = clase.fechaFin ? formatSpanishDate(new Date(clase.fechaFin)) : '—';
     const duration = calculateWeeks(clase.fechaInicio, clase.fechaFin);
     const durTxt = `${duration} ${duration === 1 ? 'semana' : 'semanas'}`;
-    const mensaje = 
+    const firstName = clase.alumnoNombre?.split(' ')[0] || '';
+    const mensaje =
       `Se ha enviado tu oferta para la clase de ${clase.asignatura}.\n` +
-      `Alumno: ${clase.alumnoNombre} ${clase.alumnoApellidos}\n` +
+      `Alumno: ${firstName}\n` +
       `Fecha inicio aprox.: ${inicioTxt}\n` +
       `Fecha fin aprox.: ${finTxt}\n` +
       `Duración aprox.: ${durTxt}\n` +
@@ -769,8 +770,7 @@ export default function Ofertas() {
               <CardHeader>
                 <HeaderLeft>
                   <StudentName>
-                    {c.alumnoNombre}
-                    {c.padreNombre ? ` (${c.padreNombre})` : ` ${c.alumnoApellidos || ''}`}
+                    {c.alumnoNombre?.split(' ')[0]}
                   </StudentName>
                   <HeaderBadges>
                     <Badge variant="asignatura">{c.asignatura}</Badge>


### PR DESCRIPTION
## Summary
- hide parent name and surnames when displaying class offers
- show only first surname and parent name on union chats

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686174f66508832b8495c9e6a5ea3a0a