### PR TITLE
Improve parent flow when no child selected

### DIFF
--- a/src/screens/alumno/PanelAlumno.jsx
+++ b/src/screens/alumno/PanelAlumno.jsx
@@ -1,7 +1,8 @@
 // src/screens/alumno/PanelAlumno.jsx
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { auth } from '../../firebase/firebaseConfig';
 import { useAuth } from '../../AuthContext';
 import { useChild } from '../../ChildContext';
 import { useNotification } from '../../NotificationContext';
@@ -94,6 +95,15 @@ const Content = styled.div`
   margin: 0 auto;       /* centra dentro del espacio disponible */
 `;
 
+const CenterMessage = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  min-height: 60vh;
+  color: #034640;
+`;
+
 export default function PanelAlumno() {
   const [searchParams, setSearchParams] = useSearchParams();
   const initialTab = searchParams.get('tab') || 'nueva-clase';
@@ -101,6 +111,7 @@ export default function PanelAlumno() {
   const { userData } = useAuth();
   const { childList, selectedChild, setSelectedChild } = useChild();
   const { show } = useNotification();
+  const navigate = useNavigate();
 
   // Al cambiar de pestaña, subimos arriba y actualizamos la URL
   useEffect(() => {
@@ -121,7 +132,11 @@ export default function PanelAlumno() {
 
   const requireChild = component => {
     if (userData?.rol === 'padre' && !selectedChild) {
-      return <p style={{ textAlign: 'center' }}>Selecciona un hijo para continuar</p>;
+      return (
+        <CenterMessage>
+          Selecciona un hijo para continuar
+        </CenterMessage>
+      );
     }
     return component;
   };
@@ -182,13 +197,18 @@ export default function PanelAlumno() {
             </MenuItem>
           )}
         </Menu>
-        {userData?.rol === 'padre' && childList.length > 0 && (
+        {userData?.rol === 'padre' && (
           <ChildSelect>
             <label>Selecciona hijo</label>
             <select
               value={selectedChild?.id || ''}
               onChange={e => {
-                const c = childList.find(ch => ch.id === e.target.value);
+                const val = e.target.value;
+                if (val === 'add_child') {
+                  navigate(`/perfil/${auth.currentUser.uid}?addChild=1`);
+                  return;
+                }
+                const c = childList.find(ch => ch.id === val);
                 setSelectedChild(c || null);
               }}
             >
@@ -198,6 +218,7 @@ export default function PanelAlumno() {
                   {c.nombre}
                 </option>
               ))}
+              <option value="add_child">Añadir hijo</option>
             </select>
           </ChildSelect>
         )}

--- a/src/screens/shared/Perfil.jsx
+++ b/src/screens/shared/Perfil.jsx
@@ -1,7 +1,7 @@
 // src/screens/shared/Perfil.jsx
 import { useState, useEffect } from 'react';
 import styled, { keyframes } from 'styled-components';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import { auth, db, storage } from '../../firebase/firebaseConfig';
 import {
   collection,
@@ -233,6 +233,7 @@ const cursosGrouped = [
 
 export default function Perfil() {
   const { userId } = useParams();
+  const [searchParams] = useSearchParams();
   const [profile, setProfile] = useState(null);
   const [isEditing, setIsEditing] = useState(false);
   const [formData, setFormData] = useState({ telefono: '', ciudad: '' });
@@ -254,6 +255,12 @@ export default function Perfil() {
   const [savingChild, setSavingChild] = useState(false);
 
   const { setChildList, setSelectedChild } = useChild();
+
+  useEffect(() => {
+    if (searchParams.get('addChild') === '1') {
+      setShowAddChild(true);
+    }
+  }, [searchParams]);
 
   const isOwnProfile = auth.currentUser && auth.currentUser.uid === userId;
   const progressInfo = getProgressData(metrics.totalClases);


### PR DESCRIPTION
## Summary
- allow navigating to quick child creation from dropdown
- show placeholder message centered when no child selected
- enable optional addChild param in profile page

## Testing
- `npm test --silent` *(fails: No tests found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861740301b8832babaa8874a277d9c6