### PR TITLE
Default today's date in teacher class proposal

### DIFF
--- a/src/screens/profesor/acciones/MisAlumnos.jsx
+++ b/src/screens/profesor/acciones/MisAlumnos.jsx
@@ -418,7 +418,8 @@ export default function MisAlumnos() {
   const openProposal = union => {
     setSelectedUnion(union);
     setOpenProposalModal(true);
-    setFechaClase('');
+    const today = new Date().toISOString().slice(0, 10);
+    setFechaClase(today);
     setDuracion('');
     setAsignMateria('');
     setModalidad('online');


### PR DESCRIPTION
## Summary
- set today's date automatically when the professor clicks **Subir clase +**

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686176f61d90832bab6c3e6a83fccd85