### PR TITLE
Add simple unread notifications

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -31,6 +31,7 @@ import MisProfesores   from './screens/alumno/acciones/MisProfesores';
 import MisAlumnos      from './screens/profesor/acciones/MisAlumnos';
 import Perfil          from './screens/shared/Perfil';
 import LoadingScreen   from './components/LoadingScreen';
+import NotificationBell from './components/NotificationBell';
 import SeleccionRol    from './screens/SeleccionRol';
 import CompletarDatosGoogle from './screens/CompletarDatosGoogle';
 
@@ -47,6 +48,7 @@ const Main = styled.main`
 const Layout = () => (
   <>
     <Navbar />
+    <NotificationBell />
     <Main><Outlet/></Main>
     <Footer />
   </>

--- a/src/NotificationsStore.js
+++ b/src/NotificationsStore.js
@@ -1,0 +1,58 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { auth, db } from './firebase/firebaseConfig';
+import { onAuthStateChanged } from 'firebase/auth';
+import { collection, query, where, onSnapshot, doc, updateDoc } from 'firebase/firestore';
+
+const NotificationsContext = createContext();
+
+export function NotificationsProvider({ children }) {
+  const [notifications, setNotifications] = useState([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+
+  useEffect(() => {
+    const unsubAuth = onAuthStateChanged(auth, user => {
+      if (!user) {
+        setNotifications([]);
+        setUnreadCount(0);
+        return;
+      }
+      const q = query(
+        collection(db, 'notificaciones'),
+        where('userId', '==', user.uid),
+        where('read', '==', false)
+      );
+      const unsub = onSnapshot(q, snap => {
+        const items = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+        setNotifications(items);
+        setUnreadCount(items.length);
+      });
+      return unsub;
+    });
+    return () => unsubAuth();
+  }, []);
+
+  const markAsRead = async id => {
+    try {
+      await updateDoc(doc(db, 'notificaciones', id), { read: true });
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const markAllAsRead = async () => {
+    const promises = notifications.map(n => updateDoc(doc(db, 'notificaciones', n.id), { read: true }));
+    try {
+      await Promise.all(promises);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <NotificationsContext.Provider value={{ notifications, unreadCount, markAsRead, markAllAsRead }}>
+      {children}
+    </NotificationsContext.Provider>
+  );
+}
+
+export const useNotificationsStore = () => useContext(NotificationsContext);

--- a/src/components/NotificationBell.jsx
+++ b/src/components/NotificationBell.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useNotificationsStore } from '../NotificationsStore';
+
+const BellWrapper = styled.div`
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  font-size: 1.5rem;
+  z-index: 1200;
+`;
+
+const Bubble = styled.div`
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background: red;
+  color: white;
+  border-radius: 50%;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+`;
+
+export default function NotificationBell() {
+  const { unreadCount } = useNotificationsStore();
+  if (unreadCount === 0) return null;
+  return (
+    <BellWrapper>
+      🔔
+      <Bubble>{unreadCount}</Bubble>
+    </BellWrapper>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import { NotificationProvider } from './NotificationContext';
+import { NotificationsProvider } from './NotificationsStore';
 import { AuthProvider } from './AuthContext';
 import { ChildProvider } from './ChildContext';
 import reportWebVitals from './reportWebVitals';
@@ -17,9 +18,11 @@ root.render(
       <GlobalStyle />
       <AuthProvider>
         <ChildProvider>
-          <NotificationProvider>
-            <App />
-          </NotificationProvider>
+          <NotificationsProvider>
+            <NotificationProvider>
+              <App />
+            </NotificationProvider>
+          </NotificationsProvider>
         </ChildProvider>
       </AuthProvider>
     </ThemeProvider>

--- a/src/screens/alumno/acciones/MisProfesores.jsx
+++ b/src/screens/alumno/acciones/MisProfesores.jsx
@@ -287,6 +287,15 @@ export default function MisProfesores() {
         createdAt: serverTimestamp()
       }
     );
+    const union = unions.find(u => u.id === chatUnionId);
+    if (union) {
+      await addDoc(collection(db, 'notificaciones'), {
+        userId: union.profesorId,
+        text: input.trim(),
+        read: false,
+        createdAt: serverTimestamp()
+      });
+    }
     setInput('');
   };
 

--- a/src/screens/profesor/acciones/MisAlumnos.jsx
+++ b/src/screens/profesor/acciones/MisAlumnos.jsx
@@ -411,6 +411,15 @@ export default function MisAlumnos() {
         createdAt: serverTimestamp()
       }
     );
+    const union = unions.find(u => u.id === chatUnionId);
+    if (union) {
+      await addDoc(collection(db, 'notificaciones'), {
+        userId: union.alumnoId,
+        text: input.trim(),
+        read: false,
+        createdAt: serverTimestamp()
+      });
+    }
     setInput('');
   };
 


### PR DESCRIPTION
## Summary
- show a notification bell overlay with unread count
- track per-user unread notifications via `NotificationsStore`
- create notification documents when sending chat messages

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686179f57a1c832b8021584f63f98b99