### PR TITLE
Implement multi-subject support

### DIFF
--- a/src/screens/admin/acciones/GestionClases.jsx
+++ b/src/screens/admin/acciones/GestionClases.jsx
@@ -328,8 +328,8 @@ export default function GestionClases() {
                   </NameLink>
                 </div>
                 <div>
-                  <Label>Asignatura:</Label>{' '}
-                  <Value>{c.asignatura}</Value>
+                  <Label>Asignaturas:</Label>{' '}
+                  <Value>{c.asignaturas ? c.asignaturas.join(', ') : c.asignatura}</Value>
                 </div>
                 <div>
                   <Label>Curso:</Label>{' '}
@@ -440,6 +440,9 @@ export default function GestionClases() {
                         <br />
                         <Label>Precio:</Label>{' '}
                         <Value>€{o.precio}</Value>
+                        <br />
+                        <Label>Asignaturas prof.:</Label>{' '}
+                        <Value>{o.asignaturas ? o.asignaturas.join(', ') : (c.asignaturas ? c.asignaturas.join(', ') : c.asignatura)}</Value>
                       </div>
                       <AcceptText
                         onClick={() => {

--- a/src/screens/alumno/acciones/NuevaClase.jsx
+++ b/src/screens/alumno/acciones/NuevaClase.jsx
@@ -315,7 +315,7 @@ const daysOfWeek = ['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sába
 const hours = Array.from({ length: 14 }, (_, i) => 8 + i);
 
 export default function NuevaClase() {
-  const [asignatura, setAsignatura]       = useState('');
+  const [asignaturas, setAsignaturas]     = useState([]);
   const [curso, setCurso]                 = useState('');
   const [tipoClase, setTipoClase]         = useState('individual');
   const [modalidad, setModalidad]         = useState('online');
@@ -448,7 +448,7 @@ export default function NuevaClase() {
   // Validar y abrir modal
   const handleSubmit = () => {
     if (
-      !asignatura ||
+      asignaturas.length === 0 ||
       !curso ||
       !ciudad ||
       !startDate ||
@@ -465,7 +465,7 @@ export default function NuevaClase() {
 
   // Restablecer todos los campos del formulario
   const resetForm = () => {
-    setAsignatura('');
+    setAsignaturas([]);
     setCurso('');
     setTipoClase('individual');
     setModalidad('online');
@@ -492,7 +492,8 @@ export default function NuevaClase() {
         alumnoApellidos,
         hijoId: userData?.rol === 'padre' ? selectedChild?.id : null,
         padreNombre: userData?.rol === 'padre' ? userData.nombre : null,
-        asignatura,
+        asignatura: asignaturas[0] || '',
+        asignaturas,
         curso,
         tipoClase,
         modalidad,
@@ -532,16 +533,21 @@ export default function NuevaClase() {
             <label>Asignatura *</label>
             <DropdownContainer>
               <DropdownHeader onClick={() => setOpenAsign(o => !o)}>
-                {asignatura || 'Selecciona asignatura'} <ArrowSpan>{openAsign ? '▲' : '▼'}</ArrowSpan>
+                {asignaturas.length > 0 ? asignaturas.join(', ') : 'Selecciona asignaturas'} <ArrowSpan>{openAsign ? '▲' : '▼'}</ArrowSpan>
               </DropdownHeader>
               {openAsign && (
                 <DropdownList>
                   {asignaturasList.map((a,i) => (
-                    <DropdownItem
-                      key={i}
-                      onClick={() => { setAsignatura(a); setOpenAsign(false); }}
-                    >
-                      {a}
+                    <DropdownItem key={i} onClick={() => {
+                      setAsignaturas(prev =>
+                        prev.includes(a)
+                          ? prev.filter(s => s !== a)
+                          : [...prev, a]
+                      );
+                    }}>
+                      <label style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+                        <input type="checkbox" checked={asignaturas.includes(a)} readOnly /> {a}
+                      </label>
                     </DropdownItem>
                   ))}
                 </DropdownList>


### PR DESCRIPTION
## Summary
- allow selecting several subjects when requesting a new teacher
- let teachers pick which requested subjects they can teach
- show subjects lists in admin offer management

## Testing
- `npm test --silent`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68617a2eae10832baf6a3289cac3820e