### PR TITLE
Add floating child selector

### DIFF
--- a/src/components/AddChildModal.jsx
+++ b/src/components/AddChildModal.jsx
@@ -1,0 +1,157 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { auth, db } from '../firebase/firebaseConfig';
+import { doc, updateDoc } from 'firebase/firestore';
+import { useChild } from '../ChildContext';
+
+const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1500;
+`;
+
+const Modal = styled.div`
+  background: #fff;
+  border-radius: 10px;
+  padding: 2rem 1.5rem;
+  width: 100%;
+  max-width: 420px;
+  box-shadow: 0 12px 36px rgba(0,0,0,0.2);
+  position: relative;
+`;
+
+const CloseButton = styled.button`
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  cursor: pointer;
+`;
+
+const Title = styled.h2`
+  margin: 0 0 1rem;
+  color: #014F40;
+`;
+
+const Input = styled.input`
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+`;
+
+const Select = styled.select`
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+`;
+
+const Button = styled.button`
+  width: 100%;
+  background: #ccf3e5;
+  color: #034640;
+  padding: 0.75rem 1rem;
+  border: none;
+  border-radius: 6px;
+  font-weight: 700;
+  cursor: pointer;
+  opacity: ${p => (p.disabled ? 0.6 : 1)};
+`;
+
+const cursosGrouped = [
+  {
+    group: 'Primaria',
+    options: [
+      '1º Primaria',
+      '2º Primaria',
+      '3º Primaria',
+      '4º Primaria',
+      '5º Primaria',
+      '6º Primaria'
+    ]
+  },
+  {
+    group: 'ESO',
+    options: ['1º ESO', '2º ESO', '3º ESO', '4º ESO']
+  },
+  {
+    group: 'Bachillerato',
+    options: ['1º Bachillerato', '2º Bachillerato']
+  }
+];
+
+export default function AddChildModal({ open, onClose }) {
+  const { childList, setChildList, setSelectedChild } = useChild();
+  const [name, setName] = useState('');
+  const [date, setDate] = useState('');
+  const [course, setCourse] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const addChild = async () => {
+    if (!name || !date || !course || saving) return;
+    setSaving(true);
+    const nuevo = {
+      id: Date.now().toString(),
+      nombre: name,
+      fechaNacimiento: date,
+      curso: course,
+      photoURL: ''
+    };
+    const nuevos = [...childList, nuevo];
+    await updateDoc(doc(db, 'usuarios', auth.currentUser.uid), { hijos: nuevos });
+    setChildList(nuevos);
+    setSelectedChild(nuevo);
+    setName('');
+    setDate('');
+    setCourse('');
+    setSaving(false);
+    onClose();
+  };
+
+  if (!open) return null;
+
+  return (
+    <Overlay onClick={onClose}>
+      <Modal onClick={e => e.stopPropagation()}>
+        <CloseButton onClick={onClose}>✕</CloseButton>
+        <Title>Añadir hijo</Title>
+        <Input
+          type="text"
+          placeholder="Nombre"
+          value={name}
+          onChange={e => setName(e.target.value)}
+        />
+        <Input
+          type="date"
+          value={date}
+          onChange={e => setDate(e.target.value)}
+        />
+        <Select value={course} onChange={e => setCourse(e.target.value)}>
+          <option value="">Selecciona curso</option>
+          {cursosGrouped.map(({ group, options }) => (
+            <optgroup key={group} label={group}>
+              {options.map(o => (
+                <option key={o} value={o}>{o}</option>
+              ))}
+            </optgroup>
+          ))}
+        </Select>
+        <Button onClick={addChild} disabled={saving}>
+          {saving ? 'Guardando...' : 'Guardar'}
+        </Button>
+      </Modal>
+    </Overlay>
+  );
+}

--- a/src/components/ChildSelectorBubble.jsx
+++ b/src/components/ChildSelectorBubble.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useChild } from '../ChildContext';
+
+const Bubble = styled.div`
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+  background: #fff;
+  padding: 0.75rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+  z-index: 1100;
+`;
+
+const Label = styled.label`
+  display: block;
+  margin-bottom: 0.25rem;
+  color: #034640;
+  font-weight: 600;
+`;
+
+const Select = styled.select`
+  width: 180px;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+`;
+
+export default function ChildSelectorBubble({ onAddChild }) {
+  const { childList, selectedChild, setSelectedChild } = useChild();
+
+  const handleChange = e => {
+    const val = e.target.value;
+    if (val === 'add_child') {
+      if (onAddChild) onAddChild();
+      return;
+    }
+    const c = childList.find(ch => ch.id === val);
+    setSelectedChild(c || null);
+  };
+
+  return (
+    <Bubble>
+      <Label>Selecciona hijo</Label>
+      <Select value={selectedChild?.id || ''} onChange={handleChange}>
+        <option value="">Selecciona tu hijo</option>
+        {childList.map(c => (
+          <option key={c.id} value={c.id}>{c.nombre}</option>
+        ))}
+        <option value="add_child">Añadir hijo</option>
+      </Select>
+    </Bubble>
+  );
+}

--- a/src/screens/alumno/PanelAlumno.jsx
+++ b/src/screens/alumno/PanelAlumno.jsx
@@ -1,11 +1,12 @@
 // src/screens/alumno/PanelAlumno.jsx
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { useSearchParams, useNavigate } from 'react-router-dom';
-import { auth } from '../../firebase/firebaseConfig';
+import { useSearchParams } from 'react-router-dom';
 import { useAuth } from '../../AuthContext';
 import { useChild } from '../../ChildContext';
 import { useNotification } from '../../NotificationContext';
+import ChildSelectorBubble from '../../components/ChildSelectorBubble';
+import AddChildModal from '../../components/AddChildModal';
 
 // importa tus pantallas “incrustadas”
 import NuevaClase    from './acciones/NuevaClase';
@@ -70,22 +71,6 @@ const Button = styled.button`
   }
 `;
 
-const ChildSelect = styled.div`
-  margin-top: auto;
-  padding-top: 1rem;
-  label {
-    display: block;
-    margin-bottom: 0.25rem;
-    color: #034640;
-    font-weight: 600;
-  }
-  select {
-    width: 100%;
-    padding: 0.5rem;
-    border: 1px solid #ccc;
-    border-radius: 6px;
-  }
-`;
 
 const Content = styled.div`
   flex: 1;
@@ -109,9 +94,9 @@ export default function PanelAlumno() {
   const initialTab = searchParams.get('tab') || 'nueva-clase';
   const [view, setView] = useState(initialTab);
   const { userData } = useAuth();
-  const { childList, selectedChild, setSelectedChild } = useChild();
+  const { selectedChild } = useChild();
   const { show } = useNotification();
-  const navigate = useNavigate();
+  const [showAddChild, setShowAddChild] = useState(false);
 
   // Al cambiar de pestaña, subimos arriba y actualizamos la URL
   useEffect(() => {
@@ -150,6 +135,7 @@ export default function PanelAlumno() {
   };
 
   return (
+    <>
     <Container>
       <Sidebar>
         <Logo>Alumno</Logo>
@@ -197,36 +183,18 @@ export default function PanelAlumno() {
             </MenuItem>
           )}
         </Menu>
-        {userData?.rol === 'padre' && (
-          <ChildSelect>
-            <label>Selecciona hijo</label>
-            <select
-              value={selectedChild?.id || ''}
-              onChange={e => {
-                const val = e.target.value;
-                if (val === 'add_child') {
-                  navigate(`/perfil/${auth.currentUser.uid}?addChild=1`);
-                  return;
-                }
-                const c = childList.find(ch => ch.id === val);
-                setSelectedChild(c || null);
-              }}
-            >
-              <option value="">Selecciona tu hijo</option>
-              {childList.map(c => (
-                <option key={c.id} value={c.id}>
-                  {c.nombre}
-                </option>
-              ))}
-              <option value="add_child">Añadir hijo</option>
-            </select>
-          </ChildSelect>
-        )}
       </Sidebar>
 
       <Content>
         {renderView()}
       </Content>
     </Container>
+    {userData?.rol === 'padre' && (
+      <>
+        <ChildSelectorBubble onAddChild={() => setShowAddChild(true)} />
+        <AddChildModal open={showAddChild} onClose={() => setShowAddChild(false)} />
+      </>
+    )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- implement `AddChildModal` for quick child registration
- create `ChildSelectorBubble` as a fixed bottom-left control
- update parent panel to use the floating child selector

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686281ab4adc832b8c095ac1b70c9231