### PR TITLE
Add notification on child change

### DIFF
--- a/src/components/ChildSelectorBubble.jsx
+++ b/src/components/ChildSelectorBubble.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useChild } from '../ChildContext';
-import { useNotification } from '../NotificationContext';
 
 const Bubble = styled.div`
   position: fixed;
@@ -30,7 +29,6 @@ const Select = styled.select`
 
 export default function ChildSelectorBubble({ onAddChild }) {
   const { childList, selectedChild, setSelectedChild } = useChild();
-  const { show } = useNotification();
 
   const handleChange = e => {
     const val = e.target.value;
@@ -40,8 +38,6 @@ export default function ChildSelectorBubble({ onAddChild }) {
     }
     const c = childList.find(ch => ch.id === val);
     setSelectedChild(c || null);
-    if (c) show(`Ahora estás usando a ${c.nombre}`);
-    else show('No hay hijo seleccionado');
   };
 
   return (

--- a/src/screens/alumno/PanelAlumno.jsx
+++ b/src/screens/alumno/PanelAlumno.jsx
@@ -1,5 +1,5 @@
 // src/screens/alumno/PanelAlumno.jsx
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { useSearchParams } from 'react-router-dom';
 import { useAuth } from '../../AuthContext';
@@ -97,6 +97,21 @@ export default function PanelAlumno() {
   const { selectedChild } = useChild();
   const { show } = useNotification();
   const [showAddChild, setShowAddChild] = useState(false);
+  const firstRender = useRef(true);
+
+  useEffect(() => {
+    if (firstRender.current) {
+      firstRender.current = false;
+      return;
+    }
+    if (userData?.rol === 'padre') {
+      if (selectedChild) {
+        show(`Ahora estás usando a ${selectedChild.nombre}`);
+      } else {
+        show('No hay hijo seleccionado');
+      }
+    }
+  }, [selectedChild, userData, show]);
 
   // Al cambiar de pestaña, subimos arriba y actualizamos la URL
   useEffect(() => {


### PR DESCRIPTION
## Summary
- display toast in PanelAlumno when selected child changes
- remove notification from ChildSelectorBubble

## Testing
- `npm test -- -w 1`

------
https://chatgpt.com/codex/tasks/task_e_6862866803bc832b8bf50a3d3be5b2d2