### PR TITLE
Remove duplicate profile name

### DIFF
--- a/src/screens/shared/Perfil.jsx
+++ b/src/screens/shared/Perfil.jsx
@@ -499,9 +499,6 @@ export default function Perfil() {
             )}
           </PhotoWrapper>
           <div>
-            <h2>
-              {profile.nombre} {profile.apellido}
-            </h2>
             <p>{profile.email}</p>
             {isEditing ? (
               <>


### PR DESCRIPTION
## Summary
- show email directly under profile picture and remove duplicated name

## Testing
- `npm test --silent`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68628697857c832b9fae93b26de6f84f