### PR TITLE
Add Firestore email trigger

### DIFF
--- a/functions/.eslintrc.js
+++ b/functions/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  root: true,
   env: {
     es6: true,
     node: true,


### PR DESCRIPTION
## Summary
- add a Cloud Function that listens for teacher assignment on a class
- create mail documents for the student/parent and teacher via the email extension
- mark functions ESLint config as project root so lint passes

## Testing
- `npm install` inside `functions`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862ac478480832b82dbd625929a7236