### PR TITLE
Implement custom password reset email

### DIFF
--- a/src/components/PasswordResetModal.jsx
+++ b/src/components/PasswordResetModal.jsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { sendPasswordResetEmail } from 'firebase/auth';
-import { auth } from '../firebase/firebaseConfig';
-import { getAuthErrorMessage } from '../utils/authErrorMessages';
+import { httpsCallable } from 'firebase/functions';
+import { functions } from '../firebase/firebaseConfig';
 import logo from '../assets/logonavbar.png';
 
 const Overlay = styled.div`
@@ -95,11 +94,12 @@ export default function PasswordResetModal({ open, onClose }) {
     setSuccess('');
     setSending(true);
     try {
-      await sendPasswordResetEmail(auth, email, { url: window.location.origin + '/inicio' });
+      const sendReset = httpsCallable(functions, 'sendCustomPasswordResetEmail');
+      await sendReset({ email });
       setSuccess('Hemos enviado un correo para restablecer tu contraseña.');
       setEmail('');
     } catch (err) {
-      setError(getAuthErrorMessage(err.code));
+      setError(err?.message || 'Se produjo un error. Inténtalo de nuevo.');
     } finally {
       setSending(false);
     }

--- a/src/firebase/firebaseConfig.js
+++ b/src/firebase/firebaseConfig.js
@@ -6,6 +6,7 @@ import { getAnalytics }    from 'firebase/analytics';
 import { getAuth }         from 'firebase/auth';
 import { getFirestore }    from 'firebase/firestore';
 import { getStorage }      from 'firebase/storage';
+import { getFunctions }    from 'firebase/functions';
 
 // 2) Tu configuración de Firebase (la misma que ya tenías)
 const firebaseConfig = {
@@ -26,6 +27,7 @@ const analytics = getAnalytics(app);
 export const auth      = getAuth(app);
 export const db        = getFirestore(app);
 export const storage   = getStorage(app);
+export const functions = getFunctions(app);
 
 // 5) Opcionalmente exporta analytics si lo necesitas en alguna parte
 export { analytics };


### PR DESCRIPTION
## Summary
- create a new Cloud Function `sendCustomPasswordResetEmail`
- expose Firebase Functions client in firebaseConfig
- update password reset modal to call the new Cloud Function

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npm --prefix functions run lint`
- `CI=true npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862af7464f4832ba70df1b25276719b