### PR TITLE
Add status and IBAN fields

### DIFF
--- a/src/screens/admin/acciones/GestionClases.jsx
+++ b/src/screens/admin/acciones/GestionClases.jsx
@@ -235,11 +235,15 @@ export default function GestionClases() {
                   let studies = '';
                   let job = '';
                   let studyTime = '';
+                  let status = '';
+                  let iban = '';
                   if (tSnap.exists()) {
                     const d = tSnap.data();
                     studies = d.studies || '';
                     job = d.job || '';
                     studyTime = d.studyTime || '';
+                    status = d.status || '';
+                    iban = d.iban || '';
                   }
                   const unionsSnap = await getDocs(
                     query(collection(db, 'clases_union'), where('profesorId', '==', tId))
@@ -254,10 +258,10 @@ export default function GestionClases() {
                     );
                     classesCount += clSnap.size;
                   }
-                  teacherCache[tId] = { studies, job, studyTime, classesCount };
+                  teacherCache[tId] = { studies, job, studyTime, status, iban, classesCount };
                 } catch (err) {
                   console.error(err);
-                  teacherCache[tId] = { studies: '', job: '', studyTime: '', classesCount: 0 };
+                  teacherCache[tId] = { studies: '', job: '', studyTime: '', status: '', iban: '', classesCount: 0 };
                 }
               }
               offer.teacherInfo = teacherCache[tId];
@@ -484,6 +488,12 @@ export default function GestionClases() {
                             <br />
                             <Label>Tiempo estudiando:</Label>{' '}
                             <Value>{o.teacherInfo.studyTime || '-'}</Value>
+                            <br />
+                            <Label>Situación:</Label>{' '}
+                            <Value>{o.teacherInfo.status || '-'}</Value>
+                            <br />
+                            <Label>IBAN:</Label>{' '}
+                            <Value>{o.teacherInfo.iban || '-'}</Value>
                             <br />
                             <Label>Clases impartidas:</Label>{' '}
                             <Value>{o.teacherInfo.classesCount}</Value>

--- a/src/screens/profesor/acciones/Ofertas.jsx
+++ b/src/screens/profesor/acciones/Ofertas.jsx
@@ -528,7 +528,10 @@ export default function Ofertas() {
       userData.docType &&
       userData.studies &&
       userData.studyTime &&
-      userData.job && userData.job !== '';
+      userData.job &&
+      userData.job !== '' &&
+      userData.status &&
+      userData.iban;
     if (!profileComplete) {
       setShowProfileModal(true);
       return false;

--- a/src/screens/shared/Perfil.jsx
+++ b/src/screens/shared/Perfil.jsx
@@ -243,6 +243,8 @@ export default function Perfil() {
     studyTime: '',
     careerFinished: false,
     job: '',
+    status: '',
+    iban: '',
   });
   const [role, setRole] = useState(null); // 'alumno' o 'profesor'
   const [unions, setUnions] = useState([]); // todas las uniones del usuario
@@ -277,17 +279,21 @@ export default function Perfil() {
     await updateDoc(doc(db, 'usuarios', userId), {
       ciudad: formData.ciudad,
       studies: formData.studies,
-      studyTime: formData.studyTime,
+      studyTime: formData.status === 'trabaja' ? 'Finalizado en tiempo' : formData.studyTime,
       careerFinished: formData.careerFinished,
       job: formData.job,
+      status: formData.status,
+      iban: formData.iban,
     });
     setProfile(p => ({
       ...p,
       ciudad: formData.ciudad,
       studies: formData.studies,
-      studyTime: formData.studyTime,
+      studyTime: formData.status === 'trabaja' ? 'Finalizado en tiempo' : formData.studyTime,
       careerFinished: formData.careerFinished,
       job: formData.job,
+      status: formData.status,
+      iban: formData.iban,
     }));
     setIsEditing(false);
   };
@@ -342,6 +348,8 @@ export default function Perfil() {
           studyTime: data.studyTime || '',
           careerFinished: data.careerFinished || false,
           job: data.job || '',
+          status: data.status || '',
+          iban: data.iban || '',
         });
         setRole(data.rol || null);
       }
@@ -534,6 +542,16 @@ export default function Perfil() {
                 />
                 {role === 'profesor' && (
                   <>
+                    <SelectInput
+                      value={formData.status}
+                      onChange={e =>
+                        setFormData({ ...formData, status: e.target.value })
+                      }
+                    >
+                      <option value="">Estudias o trabajas</option>
+                      <option value="estudia">Estudio</option>
+                      <option value="trabaja">Trabajo</option>
+                    </SelectInput>
                     <InlineInput
                       value={formData.studies}
                       onChange={e =>
@@ -564,6 +582,13 @@ export default function Perfil() {
                       }
                       placeholder="Trabajo"
                     />
+                    <InlineInput
+                      value={formData.iban}
+                      onChange={e =>
+                        setFormData({ ...formData, iban: e.target.value })
+                      }
+                      placeholder="IBAN o cuenta"
+                    />
                   </>
                 )}
                 <EditButton onClick={handleSave}>Guardar</EditButton>
@@ -578,6 +603,8 @@ export default function Perfil() {
                     <p>Tiempo estudiando: {profile.studyTime || '-'}</p>
                     <p>Carrera finalizada: {profile.careerFinished ? 'Sí' : 'No'}</p>
                     <p>Trabajo: {profile.job || '-'}</p>
+                    <p>Situación: {profile.status || '-'}</p>
+                    <p>IBAN: {profile.iban || '-'}</p>
                   </>
                 )}
                 {isOwnProfile && (


### PR DESCRIPTION
## Summary
- extend teacher profile modal with status selector and IBAN
- save and display new fields in profile
- require new fields before sending offers
- show additional teacher info in admin panel

## Testing
- `npm test --silent --maxWorkers=2` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b81998b8832b9193451762c94c92