### PR TITLE
Fix Node engine for Firebase functions

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -17,7 +17,7 @@
         "firebase-functions-test": "^3.1.0"
       },
       "engines": {
-        "node": "22"
+        "node": "20"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -10,7 +10,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "22"
+    "node": "20"
   },
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
## Summary
- target Node 20 for Firebase Functions so the project can deploy on the free tier

## Testing
- `npm test --silent --unsafe-perm -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862bd272030832b9c722b71bd099d90