### PR TITLE
Add delete confirmation and disable child

### DIFF
--- a/src/ChildContext.js
+++ b/src/ChildContext.js
@@ -10,7 +10,7 @@ export const ChildProvider = ({ children }) => {
 
   useEffect(() => {
     if (userData?.rol === 'padre') {
-      const hijos = userData.hijos || [];
+      const hijos = (userData.hijos || []).filter(h => !h.disabled);
       setChildList(hijos);
       setSelectedChild(prev => {
         if (prev && hijos.some(h => h.id === prev.id)) {

--- a/src/components/AddChildModal.jsx
+++ b/src/components/AddChildModal.jsx
@@ -87,7 +87,7 @@ export default function AddChildModal({ open, onClose }) {
     };
     const nuevos = [...childList, nuevo];
     await updateDoc(doc(db, 'usuarios', auth.currentUser.uid), { hijos: nuevos });
-    setChildList(nuevos);
+    setChildList(nuevos.filter(c => !c.disabled));
     setSelectedChild(nuevo);
     setName('');
     setDate('');

--- a/src/screens/shared/Perfil.jsx
+++ b/src/screens/shared/Perfil.jsx
@@ -323,7 +323,7 @@ export default function Perfil() {
     await updateDoc(doc(db, 'usuarios', userId), { hijos: nuevos });
     setProfile(p => ({ ...p, hijos: nuevos }));
     if (auth.currentUser && auth.currentUser.uid === userId) {
-      setChildList(nuevos);
+      setChildList(nuevos.filter(c => !c.disabled));
       setSelectedChild(nuevo);
     }
     setChildName('');


### PR DESCRIPTION
## Summary
- add filtering for disabled children in `ChildContext`
- keep disabled children out of local lists when adding
- add confirmation modal in MisHijos and disable children instead of deleting
- update profile to respect disabled children

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6862ecaffcc0832b89b47b2b4385dc11