### PR TITLE
Improve card styling and loading screens

### DIFF
--- a/src/components/CommonCard.jsx
+++ b/src/components/CommonCard.jsx
@@ -1,15 +1,18 @@
 import styled from 'styled-components';
 
 const CommonCard = styled.div`
+  display: flex;
+  flex-direction: column;
   background: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.06);
-  padding: 2rem;
-  margin-bottom: 1.75rem;
-  transition: transform 0.2s, box-shadow 0.2s;
+  border: 1px solid #e0e0e0;
+  border-radius: 10px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  transition: transform 0.1s ease-in-out, box-shadow 0.2s ease-in-out;
   &:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.12);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
   }
 `;
 

--- a/src/components/InfoGrid.jsx
+++ b/src/components/InfoGrid.jsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+const InfoGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.75rem 2rem;
+  margin-bottom: 1rem;
+`;
+
+export default InfoGrid;

--- a/src/screens/admin/acciones/GestionClases.jsx
+++ b/src/screens/admin/acciones/GestionClases.jsx
@@ -3,6 +3,8 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled, { keyframes } from 'styled-components';
 import Card from '../../../components/CommonCard';
+import InfoGrid from '../../../components/InfoGrid';
+import LoadingScreen from '../../../components/LoadingScreen';
 import { db } from '../../../firebase/firebaseConfig';
 import {
   collection,
@@ -43,11 +45,6 @@ const Title = styled.h1`
 `;
 
 
-const InfoGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0.75rem 1.5rem;
-`;
 
 const Label = styled.span`
   font-weight: 500;
@@ -326,14 +323,7 @@ export default function GestionClases() {
   };
 
   if (loading) {
-    return (
-      <Page>
-        <Container>
-          <Title>Panel de Administración</Title>
-          <p style={{ textAlign: 'center', color: '#666' }}>Cargando clases...</p>
-        </Container>
-      </Page>
-    );
+    return <LoadingScreen fullscreen />;
   }
 
   return (

--- a/src/screens/admin/acciones/Profesores.jsx
+++ b/src/screens/admin/acciones/Profesores.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import styled, { keyframes } from 'styled-components';
+import LoadingScreen from '../../../components/LoadingScreen';
 import { db } from '../../../firebase/firebaseConfig';
 import {
   collection,
@@ -155,7 +156,7 @@ export default function Profesores() {
           <ClassesContainer>
             <h3>Clases de {selected.nombre}</h3>
             {loadingClasses ? (
-              <p>Cargando clases...</p>
+              <LoadingScreen />
             ) : classes.length === 0 ? (
               <p>No hay clases registradas.</p>
             ) : (

--- a/src/screens/alumno/acciones/Clases.jsx
+++ b/src/screens/alumno/acciones/Clases.jsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'react-router-dom';
 import { useChild } from '../../../ChildContext';
 import LoadingScreen from '../../../components/LoadingScreen';
 import Card from '../../../components/CommonCard';
+import InfoGrid from '../../../components/InfoGrid';
 import { auth, db } from '../../../firebase/firebaseConfig';
 import {
   collection,
@@ -101,12 +102,6 @@ const Avatar = styled.img`
   margin-right: 1rem;
 `;
 
-const InfoGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 0.75rem 2rem;
-  margin-bottom: 1rem;
-`;
 
 const Label = styled.span`
   font-weight: 500;

--- a/src/screens/profesor/acciones/Clases.jsx
+++ b/src/screens/profesor/acciones/Clases.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState, useMemo } from 'react';
 import styled, { keyframes } from 'styled-components';
 import LoadingScreen from '../../../components/LoadingScreen';
 import Card from '../../../components/CommonCard';
+import InfoGrid from '../../../components/InfoGrid';
 import { auth, db } from '../../../firebase/firebaseConfig';
 import { useNotification } from '../../../NotificationContext';
 import {
@@ -81,12 +82,6 @@ const StudentName = styled.span`
   margin-left: 0.75rem;
 `;
 
-const InfoGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 0.75rem 2rem;
-  margin-bottom: 1rem;
-`;
 
 const Label = styled.span`
   font-weight: 500;

--- a/src/screens/profesor/acciones/Ofertas.jsx
+++ b/src/screens/profesor/acciones/Ofertas.jsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import styled, { keyframes } from 'styled-components';
 import { useNotification } from '../../../NotificationContext';
 import { auth, db } from '../../../firebase/firebaseConfig';
+import InfoGrid from '../../../components/InfoGrid';
 import { useAuth } from '../../../AuthContext';
 import CompleteTeacherProfileModal from '../../../components/CompleteTeacherProfileModal';
 import {
@@ -236,12 +237,6 @@ const HeaderBadges = styled.div`
   flex-wrap: wrap;
 `;
 const HeaderRight = styled.div``;
-const InfoGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 0.75rem 2rem;
-  margin-bottom: 1rem;
-`;
 const Label = styled.span`
   font-weight: 500;
   color: #014F40;


### PR DESCRIPTION
## Summary
- standardize card component styling
- create shared `InfoGrid` component for layout
- show `LoadingScreen` on admin panels while fetching data
- replace inline grids with shared component

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68632849c2a0832b9ba5d435bf06bb3f