### PR TITLE
Improve notification styles

### DIFF
--- a/src/NotificationContext.js
+++ b/src/NotificationContext.js
@@ -15,29 +15,36 @@ const Toast = styled.div`
   transform: translateX(-50%);
   padding: 1rem 1.5rem;
   border-radius: 8px;
-  color: #fff;
+  color: #034640;
   z-index: 1000;
   box-shadow: 0 4px 12px rgba(0,0,0,0.2);
   animation: ${slideUp} 0.4s ease;
   font-size: 1rem;
   background: ${({ type }) =>
-    type === 'error' ? '#ff6b6b' : '#02c37e'};
+    type === 'error' ? '#f8d7da' : '#ccf3e5'};
+  opacity: ${({ visible }) => (visible ? 1 : 0)};
+  transition: opacity 0.4s ease;
 `;
 
 export function NotificationProvider({ children }) {
-  const [toast, setToast] = useState({ message: '', type: 'success' });
-  const [visible, setVisible] = useState(false);
+  const [toast, setToast] = useState({ message: '', type: 'success', visible: false });
+  const [display, setDisplay] = useState(false);
 
   const show = (msg, type = 'success') => {
-    setToast({ message: msg, type });
-    setVisible(true);
-    setTimeout(() => setVisible(false), 4000);
+    setToast({ message: msg, type, visible: true });
+    setDisplay(true);
+    setTimeout(() => setToast(t => ({ ...t, visible: false })), 3000);
+    setTimeout(() => setDisplay(false), 3400);
   };
 
   return (
     <NotificationContext.Provider value={{ show }}>
-      {visible && (
-        <Toast className="notification" type={toast.type}>
+      {display && (
+        <Toast
+          className="notification"
+          type={toast.type}
+          visible={toast.visible}
+        >
           {toast.message}
         </Toast>
       )}

--- a/src/index.css
+++ b/src/index.css
@@ -22,12 +22,14 @@ code {
   transform: translateX(-50%);
   padding: 1rem 1.5rem;
   border-radius: 8px;
-  color: #fff;
+  color: #034640;
   z-index: 1000;
   box-shadow: 0 4px 12px rgba(0,0,0,0.2);
   animation: slideUp 0.4s ease;
   font-size: 1rem;
+  opacity: 1;
+  transition: opacity 0.4s ease;
 }
 
-.notification.success { background: #02c37e; }
-.notification.error { background: #ff6b6b; }
+.notification.success { background: #ccf3e5; }
+.notification.error { background: #f8d7da; }


### PR DESCRIPTION
## Summary
- tweak notification colors to be less saturated
- fade notifications out automatically

## Testing
- `npm install --silent`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6863cba53070832ba4e148a6580ba055