### PR TITLE
Improve child selection alerts

### DIFF
--- a/src/NotificationContext.js
+++ b/src/NotificationContext.js
@@ -10,7 +10,7 @@ const slideUp = keyframes`
 
 const Toast = styled.div`
   position: fixed;
-  bottom: 1.5rem;
+  bottom: 2.5rem;
   left: 50%;
   transform: translateX(-50%);
   padding: 1rem 1.5rem;
@@ -30,11 +30,11 @@ export function NotificationProvider({ children }) {
   const [toast, setToast] = useState({ message: '', type: 'success', visible: false });
   const [display, setDisplay] = useState(false);
 
-  const show = (msg, type = 'success') => {
+  const show = (msg, type = 'success', duration = 3000) => {
     setToast({ message: msg, type, visible: true });
     setDisplay(true);
-    setTimeout(() => setToast(t => ({ ...t, visible: false })), 3000);
-    setTimeout(() => setDisplay(false), 3400);
+    setTimeout(() => setToast(t => ({ ...t, visible: false })), duration);
+    setTimeout(() => setDisplay(false), duration + 400);
   };
 
   return (

--- a/src/screens/alumno/PanelAlumno.jsx
+++ b/src/screens/alumno/PanelAlumno.jsx
@@ -106,9 +106,15 @@ export default function PanelAlumno() {
     }
     if (userData?.rol === 'padre') {
       if (selectedChild) {
-        show(`Ahora estás usando a ${selectedChild.nombre}`);
+        show(
+          <span>
+            Ahora estás usando a <strong>{selectedChild.nombre}</strong>
+          </span>,
+          'success',
+          2000
+        );
       } else {
-        show('No hay hijo seleccionado', 'error');
+        show('No hay hijo seleccionado', 'error', 2000);
       }
     }
   }, [selectedChild, userData, show]);


### PR DESCRIPTION
## Summary
- adjust toast position and duration
- allow custom duration for NotificationContext's `show`
- show child name in bold when selecting and use 2s notifications

## Testing
- `npx react-scripts test --watchAll=false --maxWorkers=2` *(fails: Need to install react-scripts)*

------
https://chatgpt.com/codex/tasks/task_e_6863cf2988c8832bb62793ab96f085b8