### PR TITLE
Fix delete child behavior and disable last child removal

### DIFF
--- a/src/components/FormElements.jsx
+++ b/src/components/FormElements.jsx
@@ -44,14 +44,15 @@ export const PrimaryButton = styled.button`
 `;
 
 export const DangerButton = styled.button`
-  background: #e53e3e;
+  background: ${p => (p.disabled ? '#ccc' : '#e53e3e')};
   color: #fff;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
-  cursor: pointer;
+  cursor: ${p => (p.disabled ? 'not-allowed' : 'pointer')};
+  opacity: ${p => (p.disabled ? 0.6 : 1)};
   transition: background 0.2s ease;
   &:hover {
-    background: #c53030;
+    background: ${p => (p.disabled ? '#ccc' : '#c53030')};
   }
 `;

--- a/src/screens/alumno/acciones/MisHijos.jsx
+++ b/src/screens/alumno/acciones/MisHijos.jsx
@@ -148,7 +148,17 @@ export default function MisHijos() {
                   <div style={{ fontSize: '0.8rem', color: '#555' }}>{c.fechaNacimiento}</div>
                 </div>
               </div>
-              <DangerButton onClick={() => setChildToDelete(c)}>Eliminar</DangerButton>
+              <DangerButton
+                disabled={childList.length <= 1}
+                title={
+                  childList.length <= 1
+                    ? 'Deberás añadir un hijo antes de eliminar el último que tienes'
+                    : ''
+                }
+                onClick={() => setChildToDelete(c)}
+              >
+                Eliminar
+              </DangerButton>
             </Item>
           ))}
         </List>
@@ -181,7 +191,13 @@ export default function MisHijos() {
             </ModalText>
             <ModalActions>
               <ModalButton onClick={() => setChildToDelete(null)}>Cancelar</ModalButton>
-              <ModalButton primary onClick={() => { removeChild(childToDelete); }}>
+              <ModalButton
+                primary
+                onClick={() => {
+                  removeChild(childToDelete);
+                  setChildToDelete(null);
+                }}
+              >
                 Aceptar
               </ModalButton>
             </ModalActions>


### PR DESCRIPTION
## Summary
- style `DangerButton` when disabled
- prevent removing the last child
- close deletion modal after confirming

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68655593047c832baa6a06ef7f32546d