### PR TITLE
Update default end date to 2026

### DIFF
--- a/src/screens/alumno/acciones/NuevaClase.jsx
+++ b/src/screens/alumno/acciones/NuevaClase.jsx
@@ -440,9 +440,8 @@ export default function NuevaClase() {
   const handleNoEndDateChange = (checked) => {
     setNoEndDate(checked);
     if (checked) {
-      const year = new Date().getFullYear();
-      // Fecha de fin de curso: 23 de junio del año actual
-      setEndDate(`${year}-06-23`);
+      // Fecha de fin de curso: 23 de junio de 2026
+      setEndDate('2026-06-23');
     } else {
       setEndDate('');
     }


### PR DESCRIPTION
## Summary
- adjust "sin fecha de fin planeada" handler so default end date is June 23, 2026

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686556efaea0832bbfccd09ccc9ca2ea