### PR TITLE
Fix profile completion logic

### DIFF
--- a/src/screens/profesor/acciones/Ofertas.jsx
+++ b/src/screens/profesor/acciones/Ofertas.jsx
@@ -512,10 +512,9 @@ export default function Ofertas() {
       userData.docType &&
       userData.studies &&
       userData.studyTime &&
-      userData.job &&
-      userData.job !== '' &&
       userData.status &&
-      userData.iban;
+      userData.iban &&
+      (userData.status !== 'trabaja' || (userData.job && userData.job !== ''));
     if (!profileComplete) {
       setShowProfileModal(true);
       return false;


### PR DESCRIPTION
## Summary
- fix CompleteTeacherProfileModal validation so it only requires `job` if `status` is `trabaja`

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68655caad674832bb86c167f67865548