### PR TITLE
Add counters for teachers and students

### DIFF
--- a/src/screens/admin/acciones/Profesores.jsx
+++ b/src/screens/admin/acciones/Profesores.jsx
@@ -35,6 +35,12 @@ const Title = styled.h1`
   font-size: 2.5rem;
 `;
 
+const Counter = styled.span`
+  font-size: 1.25rem;
+  color: #046654;
+  margin-left: 0.5rem;
+`;
+
 const List = styled.ul`
   list-style: none;
   padding: 0;
@@ -142,7 +148,7 @@ export default function Profesores() {
   return (
     <Page>
       <Container>
-        <Title>Profesores</Title>
+        <Title>Profesores<Counter>({teachers.length})</Counter></Title>
         <List>
           {teachers.map((t) => (
             <Item key={t.id} onClick={() => openTeacher(t)}>

--- a/src/screens/admin/acciones/Usuarios.jsx
+++ b/src/screens/admin/acciones/Usuarios.jsx
@@ -34,6 +34,14 @@ const Title = styled.h1`
   font-size: 2.5rem;
 `;
 
+const Counter = styled.p`
+  text-align: center;
+  color: #046654;
+  margin-top: -1rem;
+  margin-bottom: 1rem;
+  font-weight: 500;
+`;
+
 const SwitchContainer = styled.div`
   display: flex;
   justify-content: center;
@@ -202,6 +210,9 @@ export default function Usuarios() {
     <Page>
       <Container>
         <Title>Profesores &amp; Alumnos</Title>
+        <Counter>
+          Total {view === 'profesores' ? teachers.length : students.length}
+        </Counter>
         <SwitchContainer>
           <SwitchTrack>
             <SwitchBubble view={view} />


### PR DESCRIPTION
## Summary
- show how many teachers there are in `Profesores`
- show a total count of teachers or students in `Usuarios` depending on view

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_686bf0424024832ba4751626bae6409c