### PR TITLE
Fix child-specific filtering for parent views

### DIFF
--- a/src/screens/alumno/acciones/Calendario.jsx
+++ b/src/screens/alumno/acciones/Calendario.jsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import styled, { keyframes } from 'styled-components';
 import { auth, db } from '../../../firebase/firebaseConfig';
 import { collection, query, where, getDocs } from 'firebase/firestore';
+import { useChild } from '../../../ChildContext';
 import {
   startOfMonth,
   endOfMonth,
@@ -120,15 +121,23 @@ export default function Calendario() {
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [clases, setClases] = useState([]);
   const [facturacion, setFacturacion] = useState([]);
+  const { selectedChild } = useChild();
 
   useEffect(() => {
     const fetchClases = async () => {
       const u = auth.currentUser;
       if (!u) return;
-      const q = query(
+      let q = query(
         collection(db, 'clases_union'),
         where('alumnoId', '==', u.uid)
       );
+      if (selectedChild) {
+        q = query(
+          collection(db, 'clases_union'),
+          where('alumnoId', '==', u.uid),
+          where('hijoId', '==', selectedChild.id)
+        );
+      }
       const snap = await getDocs(q);
       let all = [];
       for (const docu of snap.docs) {
@@ -151,7 +160,11 @@ export default function Calendario() {
     };
     fetchClases();
     fetchFact();
-  }, []);
+  }, [selectedChild]);
+
+  useEffect(() => {
+    setClases([]);
+  }, [selectedChild]);
 
   const prevMonth = () =>
     setCurrentMonth(addDays(startOfMonth(currentMonth), -1));


### PR DESCRIPTION
## Summary
- scope chats and calendar to selected child
- reset chat and calendar data when switching children

## Testing
- `npm install --silent`
- `CI=true npm test --silent` *(fails: react-scripts not found / tests didn't run)*

------
https://chatgpt.com/codex/tasks/task_e_686bf33532e4832b8a34d6f204381177