### PR TITLE
Improve class modification flow

### DIFF
--- a/src/screens/alumno/acciones/Clases.jsx
+++ b/src/screens/alumno/acciones/Clases.jsx
@@ -295,6 +295,32 @@ export default function Clases() {
     });
   };
 
+  const acceptModification = async clase => {
+    const ref = doc(db, 'clases_union', clase.unionId, 'clases_asignadas', clase.id);
+    await updateDoc(ref, {
+      modificacionPendiente: false,
+      modificacionAceptada: serverTimestamp()
+    });
+    await addDoc(collection(db, 'clases_union', clase.unionId, 'chats'), {
+      senderId: auth.currentUser.uid,
+      text: `He aceptado la modificación para el ${clase.fecha}`,
+      createdAt: serverTimestamp()
+    });
+  };
+
+  const rejectModification = async clase => {
+    const ref = doc(db, 'clases_union', clase.unionId, 'clases_asignadas', clase.id);
+    await updateDoc(ref, {
+      modificacionPendiente: false,
+      modificacionRechazada: serverTimestamp()
+    });
+    await addDoc(collection(db, 'clases_union', clase.unionId, 'chats'), {
+      senderId: auth.currentUser.uid,
+      text: `He rechazado la modificación para el ${clase.fecha}`,
+      createdAt: serverTimestamp()
+    });
+  };
+
   const sortedClases = React.useMemo(() => {
     const arr = [...clases];
     arr.sort((a, b) => {
@@ -388,6 +414,19 @@ export default function Clases() {
                       </AcceptButton>{' '}
                       <RejectButton onClick={() => rejectProposal(c)}>
                         Rechazar
+                      </RejectButton>
+                    </div>
+                  )}
+                  {c.modificacionPendiente && (
+                    <div>
+                      <p style={{ marginTop: '0.5rem' }}>
+                        El profesor propone modificar esta clase.
+                      </p>
+                      <AcceptButton onClick={() => acceptModification(c)}>
+                        Aceptar cambio
+                      </AcceptButton>{' '}
+                      <RejectButton onClick={() => rejectModification(c)}>
+                        Rechazar cambio
                       </RejectButton>
                     </div>
                   )}

--- a/src/screens/profesor/acciones/Clases.jsx
+++ b/src/screens/profesor/acciones/Clases.jsx
@@ -359,11 +359,17 @@ export default function ClasesProfesor() {
                 <Label>Ganancia:</Label> <Value>€{(c.precioTotalProfesor || 0).toFixed(2)}</Value>
               </div>
             </InfoGrid>
-            {c.estado === 'pendiente' ? (
+            {c.estado === 'pendiente' && (
               <CancelButton onClick={() => cancelPending(c)}>
                 Cancelar propuesta
               </CancelButton>
-            ) : (
+            )}
+            {c.estado === 'aceptada' && (
+              <CancelButton onClick={() => cancelPending(c)}>
+                Cancelar clase
+              </CancelButton>
+            )}
+            {c.estado !== 'pendiente' && (
               <ModifyButton
                 disabled={!isModificationAllowed(c)}
                 onClick={() => openEdit(c)}


### PR DESCRIPTION
## Summary
- allow students to accept or reject modification proposals from the class list
- show teacher's cancel button for accepted classes

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686bf57003bc832ba97b136362fdde54