### PR TITLE
Fix missing useEffect wrapper

### DIFF
--- a/src/screens/profesor/acciones/Clases.jsx
+++ b/src/screens/profesor/acciones/Clases.jsx
@@ -286,6 +286,7 @@ export default function ClasesProfesor() {
     return () => unsub();
   }, []);
 
+  useEffect(() => {
     setSearchParams({ view });
   }, [view, setSearchParams]);
 


### PR DESCRIPTION
## Summary
- ensure `setSearchParams` is wrapped in `useEffect`

## Testing
- `npm install`
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686e45c01f14832ba012fa9e8334e698