### PR TITLE
Unify toggle switches and remove loading screen

### DIFF
--- a/src/components/ToggleSwitch.jsx
+++ b/src/components/ToggleSwitch.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const SwitchContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1rem;
+`;
+
+const SwitchTrack = styled.div`
+  position: relative;
+  display: flex;
+  width: 280px;
+  background: #f5f5f5;
+  border-radius: 20px;
+  padding: 4px;
+`;
+
+const SwitchBubble = styled.div`
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  left: 4px;
+  width: calc(50% - 4px);
+  background: #046654;
+  border-radius: 16px;
+  transition: transform 0.3s ease;
+  transform: ${({ view }) =>
+    view === 'right' ? 'translateX(100%)' : 'translateX(0)'};
+`;
+
+const SwitchButton = styled.button`
+  flex: 1;
+  background: transparent;
+  border: none;
+  padding: 0.5rem 1rem;
+  color: ${({ active }) => (active ? '#fff' : '#333')};
+  font-weight: 500;
+  position: relative;
+  z-index: 1;
+  cursor: pointer;
+`;
+
+export default function ToggleSwitch({
+  leftLabel,
+  rightLabel,
+  value,
+  onChange,
+}) {
+  return (
+    <SwitchContainer>
+      <SwitchTrack>
+        <SwitchBubble view={value} />
+        <SwitchButton
+          active={value === 'left'}
+          onClick={() => onChange('left')}
+        >
+          {leftLabel}
+        </SwitchButton>
+        <SwitchButton
+          active={value === 'right'}
+          onClick={() => onChange('right')}
+        >
+          {rightLabel}
+        </SwitchButton>
+      </SwitchTrack>
+    </SwitchContainer>
+  );
+}

--- a/src/screens/admin/acciones/Usuarios.jsx
+++ b/src/screens/admin/acciones/Usuarios.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import styled, { keyframes } from 'styled-components';
 import { Link } from 'react-router-dom';
 import LoadingScreen from '../../../components/LoadingScreen';
+import ToggleSwitch from "../../../components/ToggleSwitch";
 import { db } from '../../../firebase/firebaseConfig';
 import {
   collection,
@@ -40,46 +41,6 @@ const Counter = styled.p`
   margin-top: -1rem;
   margin-bottom: 1rem;
   font-weight: 500;
-`;
-
-const SwitchContainer = styled.div`
-  display: flex;
-  justify-content: center;
-  margin-bottom: 1rem;
-`;
-
-const SwitchTrack = styled.div`
-  position: relative;
-  display: flex;
-  width: 280px;
-  background: #e0e0e0;
-  border-radius: 20px;
-  padding: 4px;
-`;
-
-const SwitchBubble = styled.div`
-  position: absolute;
-  top: 4px;
-  bottom: 4px;
-  left: 4px;
-  width: calc(50% - 8px);
-  background: #046654;
-  border-radius: 16px;
-  transition: transform 0.3s ease;
-  transform: ${({ view }) =>
-    view === 'alumnos' ? 'translateX(100%)' : 'translateX(0)'};
-`;
-
-const SwitchButton = styled.button`
-  flex: 1;
-  background: transparent;
-  border: none;
-  padding: 0.5rem 1rem;
-  color: ${({ active }) => (active ? '#fff' : '#333')};
-  font-weight: 500;
-  position: relative;
-  z-index: 1;
-  cursor: pointer;
 `;
 
 const FilterContainer = styled.div`
@@ -220,17 +181,8 @@ export default function Usuarios() {
         <Counter>
           Total {view === 'profesores' ? teachers.length : totalStudents}
         </Counter>
-        <SwitchContainer>
-          <SwitchTrack>
-            <SwitchBubble view={view} />
-            <SwitchButton active={view === 'profesores'} onClick={() => setView('profesores')}>
-              Profesores
-            </SwitchButton>
-            <SwitchButton active={view === 'alumnos'} onClick={() => setView('alumnos')}>
-              Alumnos / Padres
-            </SwitchButton>
-          </SwitchTrack>
-        </SwitchContainer>
+        <ToggleSwitch leftLabel="Profesores" rightLabel="Alumnos / Padres" value={view === "profesores" ? "left" : "right"} onChange={(val) => setView(val === "left" ? "profesores" : "alumnos")}/>
+
         <FilterContainer>
           <label htmlFor="sortUsuarios">Ordenar por:</label>
           <select

--- a/src/screens/alumno/acciones/Clases.jsx
+++ b/src/screens/alumno/acciones/Clases.jsx
@@ -6,6 +6,7 @@ import { useChild } from '../../../ChildContext';
 import LoadingScreen from '../../../components/LoadingScreen';
 import Card from '../../../components/CommonCard';
 import InfoGrid from '../../../components/InfoGrid';
+import ToggleSwitch from "../../../components/ToggleSwitch";
 import { auth, db } from '../../../firebase/firebaseConfig';
 import {
   collection,
@@ -42,46 +43,6 @@ const Title = styled.h2`
   color: #034640;
   font-size: 2rem;
   text-align: center;
-`;
-
-const SwitchContainer = styled.div`
-  display: flex;
-  justify-content: center;
-  margin-bottom: 1rem;
-`;
-
-const SwitchTrack = styled.div`
-  position: relative;
-  display: flex;
-  width: 280px;
-  background: #f5f5f5;
-  border-radius: 20px;
-  padding: 4px;
-`;
-
-const SwitchBubble = styled.div`
-  position: absolute;
-  top: 4px;
-  bottom: 4px;
-  left: 4px;
-  width: calc(50% - 4px);
-  background: #046654;
-  border-radius: 16px;
-  transition: transform 0.3s ease;
-  transform: ${({ view }) =>
-    view === 'solicitudes' ? 'translateX(100%)' : 'translateX(0)'};
-`;
-
-const SwitchButton = styled.button`
-  flex: 1;
-  background: transparent;
-  border: none;
-  padding: 0.5rem 1rem;
-  color: ${({ active }) => (active ? '#fff' : '#333')};
-  font-weight: 500;
-  position: relative;
-  z-index: 1;
-  cursor: pointer;
 `;
 
 const FilterContainer = styled.div`
@@ -182,7 +143,6 @@ export default function Clases() {
   const [sortBy, setSortBy] = useState('fecha');
   const [loading, setLoading] = useState(true);
   const [loadingReqs, setLoadingReqs] = useState(true);
-  const [showLoading, setShowLoading] = useState(false);
   const [processingIds, setProcessingIds] = useState(new Set());
 
   useEffect(() => {
@@ -263,15 +223,6 @@ export default function Clases() {
     setSearchParams({ tab: 'clases', view });
   }, [view, setSearchParams]);
 
-  useEffect(() => {
-    let timer;
-    if ((view === 'clases' && loading) || (view === 'solicitudes' && loadingReqs)) {
-      timer = setTimeout(() => setShowLoading(true), 200);
-    } else {
-      setShowLoading(false);
-    }
-    return () => clearTimeout(timer);
-  }, [loading, loadingReqs, view]);
 
   const acceptProposal = async clase => {
     if (processingIds.has(clase.id)) return;
@@ -410,26 +361,14 @@ export default function Clases() {
   const formatDate = d => {
     return d ? new Date(d).toLocaleDateString('es-ES', { day: '2-digit', month: '2-digit', year: 'numeric' }) : '—';
   };
-
-  if (showLoading) {
-    return <LoadingScreen fullscreen />;
   }
 
   return (
     <Page>
       <Container>
         <Title>Mis Clases & Solicitudes</Title>
-        <SwitchContainer>
-          <SwitchTrack>
-            <SwitchBubble view={view} />
-            <SwitchButton active={view === 'clases'} onClick={() => setView('clases')}>
-              Mis clases
-            </SwitchButton>
-            <SwitchButton active={view === 'solicitudes'} onClick={() => setView('solicitudes')}>
-              Mis solicitudes
-            </SwitchButton>
-          </SwitchTrack>
-        </SwitchContainer>
+        <ToggleSwitch leftLabel="Mis clases" rightLabel="Mis solicitudes" value={view === "clases" ? "left" : "right"} onChange={(val) => setView(val === "left" ? "clases" : "solicitudes")}/>
+
         {view === 'clases' ? (
           <>
             <FilterContainer>

--- a/src/screens/profesor/acciones/Clases.jsx
+++ b/src/screens/profesor/acciones/Clases.jsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'react-router-dom';
 import LoadingScreen from '../../../components/LoadingScreen';
 import Card from '../../../components/CommonCard';
 import InfoGrid from '../../../components/InfoGrid';
+import ToggleSwitch from "../../../components/ToggleSwitch";
 import { auth, db } from '../../../firebase/firebaseConfig';
 import { useNotification } from '../../../NotificationContext';
 import {
@@ -42,46 +43,6 @@ const Container = styled.div`
 const Title = styled.h2`
   color: #034640;
   margin-bottom: 1rem;
-`;
-
-const SwitchContainer = styled.div`
-  display: flex;
-  justify-content: center;
-  margin-bottom: 1rem;
-`;
-
-const SwitchTrack = styled.div`
-  position: relative;
-  display: flex;
-  width: 280px;
-  background: #f5f5f5;
-  border-radius: 20px;
-  padding: 4px;
-`;
-
-const SwitchBubble = styled.div`
-  position: absolute;
-  top: 4px;
-  bottom: 4px;
-  left: 4px;
-  width: calc(50% - 4px);
-  background: #046654;
-  border-radius: 16px;
-  transition: transform 0.3s ease;
-  transform: ${({ view }) =>
-    view === 'ofertas' ? 'translateX(100%)' : 'translateX(0)'};
-`;
-
-const SwitchButton = styled.button`
-  flex: 1;
-  background: transparent;
-  border: none;
-  padding: 0.5rem 1rem;
-  color: ${({ active }) => (active ? '#fff' : '#333')};
-  font-weight: 500;
-  position: relative;
-  z-index: 1;
-  cursor: pointer;
 `;
 
 const FilterContainer = styled.div`
@@ -404,17 +365,8 @@ export default function ClasesProfesor() {
     <Page>
       <Container>
         <Title>Mis Clases & Ofertas</Title>
-        <SwitchContainer>
-          <SwitchTrack>
-            <SwitchBubble view={view} />
-            <SwitchButton active={view === 'clases'} onClick={() => setView('clases')}>
-              Mis clases
-            </SwitchButton>
-            <SwitchButton active={view === 'ofertas'} onClick={() => setView('ofertas')}>
-              Mis ofertas
-            </SwitchButton>
-          </SwitchTrack>
-        </SwitchContainer>
+        <ToggleSwitch leftLabel="Mis clases" rightLabel="Mis ofertas" value={view === "clases" ? "left" : "right"} onChange={(val) => setView(val === "left" ? "clases" : "ofertas")}/>
+
         {view === 'clases' ? (
           <>
             <FilterContainer>


### PR DESCRIPTION
## Summary
- add a shared `ToggleSwitch` component
- use `ToggleSwitch` in Alumno, Profesor and Admin class views
- remove extra loading screen logic in Alumno view

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686e4e171550832b8a1ea336a6592903