### PR TITLE
Unify button styles

### DIFF
--- a/src/components/FormElements.jsx
+++ b/src/components/FormElements.jsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 
 export const TextInput = styled.input`
   width: 100%;
@@ -54,5 +55,26 @@ export const DangerButton = styled.button`
   transition: background 0.2s ease;
   &:hover {
     background: ${p => (p.disabled ? '#ccc' : '#c53030')};
+  }
+`;
+
+export const PrimaryLink = styled(Link)`
+  display: inline-block;
+  background: ${({ theme, accent }) =>
+    accent ? theme.colors.accent : theme.colors.secondary};
+  color: ${({ theme, accent }) =>
+    accent ? '#ffffff' : theme.colors.primary};
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  font-weight: 700;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+  opacity: ${p => (p.disabled ? 0.6 : 1)};
+  pointer-events: ${p => (p.disabled ? 'none' : 'auto')};
+  &:hover {
+    background: ${({ theme, accent }) =>
+      accent ? theme.colors.accentHover : theme.colors.accent};
+    transform: translateY(-2px);
   }
 `;

--- a/src/screens/Alta.jsx
+++ b/src/screens/Alta.jsx
@@ -1,7 +1,7 @@
 // src/components/Alta.jsx
 import React from 'react';
 import styled, { keyframes } from 'styled-components';
-import { Link } from 'react-router-dom';
+import { PrimaryLink } from '../components/FormElements';
 import alumnosImg from '../assets/alumnos.jpg';
 import profesoresImg from '../assets/profesores.png';
 
@@ -92,21 +92,12 @@ const CardDesc = styled.p`
   flex: 1;
 `;
 
-const CardButton = styled(Link)`
-  display: inline-block;
-  background: #034640;
-  color: #fff;
-  text-decoration: none;
+const CardButton = styled(PrimaryLink).attrs({ accent: true })`
   padding: 0.85rem 1.75rem;
-  border-radius: 6px;
-  font-weight: 700;
   font-size: 1rem;
   text-align: center;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-  transition: background-color 0.3s ease, box-shadow 0.3s ease;
-
   &:hover {
-    background-color: #046654;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   }
 `;

--- a/src/screens/Contacto.jsx
+++ b/src/screens/Contacto.jsx
@@ -1,7 +1,7 @@
 // src/components/Contacto.jsx
 import React from 'react';
 import styled, { keyframes } from 'styled-components';
-import { Link } from 'react-router-dom';
+import { PrimaryLink } from '../components/FormElements';
 import whatsapp from '../assets/whatsapp.webp';
 import correo from '../assets/correo.webp';
 
@@ -96,15 +96,9 @@ const InfoSub = styled.p`
   line-height: 1.4;
 `;
 
-const StartButton = styled(Link)`
-  display: inline-block;
-  background-color: #02c37e;
-  color: #fff;
+const StartButton = styled(PrimaryLink).attrs({ accent: true })`
   padding: 0.6rem 1.75rem;
-  border-radius: 6px;
   font-size: 1rem;
-  font-weight: 700;
-  text-decoration: none;
   transition: transform 0.3s;
   &:hover {
     transform: translateY(-2px);

--- a/src/screens/Home.jsx
+++ b/src/screens/Home.jsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState, useEffect } from 'react';
 import styled, { keyframes } from 'styled-components';
 import { useTheme } from 'styled-components';
-import { Link } from 'react-router-dom';
+import { PrimaryLink } from '../components/FormElements';
 import banner from '../assets/banner.jpg';
 import personas from '../assets/personas.jpg';
 import bolis from '../assets/bolis.jpg';
@@ -69,21 +69,10 @@ const Subtitle = styled.p`
   margin: 2rem 0 3rem;
 `;
 
-const Button = styled(Link)`
-  display: inline-block;
-  background-color: ${({ theme }) => theme.colors.secondary};
-  color: ${({ theme }) => theme.colors.primary};
-  padding: 0.75rem 1.5rem;
-  border-radius: 4px;
-  font-weight: 700;
+const Button = styled(PrimaryLink)`
   font-size: 1.125rem;
-  text-decoration: none;
+  padding: 0.75rem 1.5rem;
   margin-bottom: 1rem;
-  transition: background-color 0.3s, transform 0.3s;
-  &:hover {
-    background-color: ${({ theme }) => theme.colors.accent};
-    transform: translateY(-4px);
-  }
 `;
 
 const InfoText = styled.p`
@@ -158,22 +147,12 @@ const SubtitleText = styled.p`
   color: ${({ theme }) => theme.colors.secondary};
 `;
 
-const CardButton = styled(Link)`
+const CardButton = styled(PrimaryLink)`
   display: block;
-  background-color: ${({ theme }) => theme.colors.secondary};
-  color: ${({ theme }) => theme.colors.primary};
-  padding: 0.65rem 1.25rem;
-  border-radius: 4px;
-  font-weight: 700;
   font-size: 0.95rem;
-  text-decoration: none;
+  padding: 0.65rem 1.25rem;
   width: fit-content;
   margin: 2rem auto 0;
-  transition: background-color 0.3s, transform 0.3s;
-  &:hover {
-    background-color: ${({ theme }) => theme.colors.accent};
-    transform: translateY(-4px);
-  }
 `;
 
 /* ============ SCROLL-REVEAL SECTION ============ */
@@ -217,23 +196,13 @@ const RevealColImage = styled(ColImage)`
   flex: 1 1 45%;
 `;
 
-const RevealButton = styled(Link)`
+const RevealButton = styled(PrimaryLink).attrs({ accent: true })`
   display: block;
-  background-color: ${({ theme }) => theme.colors.accent};
-  color: #ffffff;
-  padding: 0.75rem 1.5rem;
-  border-radius: 4px;
-  font-weight: 700;
   font-size: 1rem;
-  text-decoration: none;
+  padding: 0.75rem 1.5rem;
   width: fit-content;
   margin: 1.5rem auto 0;
   box-shadow: 0 12px 24px rgba(0,0,0,0.3);
-  transition: background-color 0.3s, transform 0.3s;
-  &:hover {
-    background-color: ${({ theme }) => theme.colors.accentHover};
-    transform: translateY(-4px);
-  }
 `;
 
 /* ============ VIDEO SECTION ============ */
@@ -279,22 +248,12 @@ const InfoSub = styled.p`
   line-height: 1.4;
 `;
 
-const StartButton = styled(Link)`
+const StartButton = styled(PrimaryLink).attrs({ accent: true })`
   display: block;
-  background-color: ${({ theme }) => theme.colors.accent};
-  color: #ffffff;
-  padding: 0.75rem 1.5rem;
-  border-radius: 4px;
-  font-weight: 700;
   font-size: 1rem;
-  text-decoration: none;
+  padding: 0.75rem 1.5rem;
   width: fit-content;
   margin: 1rem auto 0;
-  transition: background-color 0.3s, transform 0.3s;
-  &:hover {
-    background-color: ${({ theme }) => theme.colors.accentHover};
-    transform: translateY(-4px);
-  }
 `;
 
 /* ============ PARTNER SECTION ============ */

--- a/src/screens/ReservaClase.jsx
+++ b/src/screens/ReservaClase.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import styled, { keyframes } from 'styled-components';
-import { Link } from 'react-router-dom';
+import { PrimaryLink } from '../components/FormElements';
 import personas from '../assets/personas.jpg';
 import escribiendo from '../assets/escribiendo.jpg';
 
@@ -91,22 +91,14 @@ const CardText = styled.p`
   flex-grow: 1;
 `;
 
-const ReserveButton = styled(Link)`
+const ReserveButton = styled(PrimaryLink).attrs({ accent: true })`
   display: inline-block;
-  background-color: #014f40;
-  color: #ffffff;
   padding: 0.75rem 2rem;
-  border-radius: 8px;
   font-size: 1.125rem;
-  font-weight: 700;
-  text-decoration: none;
+  border-radius: 8px;
   margin-top: 1rem;
   opacity: 0;
   animation: ${slideUp} 1s ease-out 0.6s forwards;
-
-  &:hover {
-    background-color: #02332a;
-  }
 `;
 
 const VideoSection = styled.section`
@@ -153,21 +145,14 @@ const InfoSub = styled.p`
   line-height: 1.4;
 `;
 
-const StartButton = styled(Link)`
+const StartButton = styled(PrimaryLink).attrs({ accent: true })`
   display: inline-block;
-  background-color: #02c37e;
-  color: #ffffff;
   padding: 0.75rem 2rem;
   border-radius: 8px;
   font-weight: 700;
   font-size: 1rem;
-  text-decoration: none;
   opacity: 0;
   animation: ${slideUp} 1s ease-out 1.2s forwards;
-
-  &:hover {
-    background-color: #02b36e;
-  }
 `;
 
 const ProfSection = styled.section`
@@ -228,23 +213,16 @@ const ProfDesc = styled.p`
   line-height: 1.6;
 `;
 
-const ProfButton = styled(Link)`
+const ProfButton = styled(PrimaryLink)`
   display: block;
-  background-color: #ccf3e5;
-  color: #014f40;
   padding: 0.75rem 1.5rem;
   border-radius: 8px;
   font-size: 1rem;
   font-weight: 700;
-  text-decoration: none;
   margin: 2.5rem auto 0;
   width: fit-content;
   opacity: 0;
   animation: ${slideUp} 1s ease-out 1.8s forwards;
-
-  &:hover {
-    background-color: #b2e8d4;
-  }
 `;
 
 /* ========== Componente ========== */


### PR DESCRIPTION
## Summary
- add `PrimaryLink` component for styled Link buttons
- refactor Home, Alta, Contacto and ReservaClase screens to reuse new component

## Testing
- `npm run test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686e4e40b5d8832bb061556bbbaa06ed