### PR TITLE
Fix compile error in Clases screen

### DIFF
--- a/src/screens/alumno/acciones/Clases.jsx
+++ b/src/screens/alumno/acciones/Clases.jsx
@@ -361,7 +361,6 @@ export default function Clases() {
   const formatDate = d => {
     return d ? new Date(d).toLocaleDateString('es-ES', { day: '2-digit', month: '2-digit', year: 'numeric' }) : '—';
   };
-  }
 
   return (
     <Page>


### PR DESCRIPTION
## Summary
- remove stray `}` from `Clases.jsx`

## Testing
- `npx react-scripts build`
- `npx react-scripts test --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_686e539daa14832b98eb5e0d33812ec3