### PR TITLE
Fix loading screen on toggle switches

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -62,7 +62,7 @@ function AppContent() {
     setLoading(true);
     const timer = setTimeout(() => setLoading(false), 800);
     return () => clearTimeout(timer);
-  }, [location]);
+  }, [location.pathname]);
 
   return (
     <AppContainer>


### PR DESCRIPTION
## Summary
- update route change detection so the global `LoadingScreen` only appears when the path changes, not when query parameters update

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686e5675c874832bb3ad507762bddbd1