### PR TITLE
Improve Google Sheets sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,22 @@ This section has moved here: [https://facebook.github.io/create-react-app/docs/d
 ### `npm run build` fails to minify
 
 This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+
+## Google Sheets Sync
+
+The app includes a custom hook `useSyncClassToSheet` that sends class data to a Google Apps Script when a class document is marked as `aceptada` in Firestore. The hook posts using `mode: no-cors` so the request works without extra CORS headers. Configure the webhook secret in `.env`:
+
+```
+REACT_APP_SHEET_SECRET=yourSecret
+```
+
+Deploy the script in `apps-script/Code.gs` as a web app and set the same secret and spreadsheet ID in the script properties. Import and use the hook with the union and assignment IDs of the class:
+
+```jsx
+import { useSyncClassToSheet } from './hooks/useSyncClassToSheet';
+
+function Example() {
+  useSyncClassToSheet('union123', 'assignment456');
+  return null;
+}
+```

--- a/apps-script/Code.gs
+++ b/apps-script/Code.gs
@@ -1,0 +1,51 @@
+// apps-script/Code.gs
+// Google Apps Script to log classes to Google Sheets
+function doPost(e) {
+  const props = PropertiesService.getScriptProperties();
+  const SECRET = props.getProperty('SECRET');
+  const SPREADSHEET_ID = props.getProperty('SPREADSHEET_ID');
+
+  const body = JSON.parse(e.postData.contents);
+  if (body.secret !== SECRET) {
+    return ContentService.createTextOutput('UNAUTHORIZED')
+      .setMimeType(ContentService.MimeType.TEXT);
+  }
+
+  const sheet = SpreadsheetApp.openById(SPREADSHEET_ID).getSheets()[0];
+  const lastRow = sheet.getLastRow();
+  const ids = lastRow > 0 ? sheet.getRange(1, 1, lastRow, 1).getValues().flat() : [];
+  const rowIndex = ids.indexOf(body.idClase);
+
+  const beneficio = Number(body.precioTotalPadres || 0) -
+    Number(body.precioTotalProfesor || 0);
+
+  const row = [
+    body.idClase,
+    body.emailProfesor,
+    body.nombreProfesor,
+    body.emailAlumno,
+    body.nombreAlumno,
+    body.curso,
+    body.asignatura,
+    body.ciudad,
+    body.fecha,
+    body.duracion,
+    body.modalidad,
+    Number(body.numeroAlumnos || 0),
+    Number(body.precioTotalPadres || 0),
+    Number(body.precioTotalProfesor || 0),
+    beneficio,
+  ];
+
+  let result;
+  if (rowIndex !== -1) {
+    sheet.getRange(rowIndex + 1, 1, 1, row.length).setValues([row]);
+    result = 'UPDATED';
+  } else {
+    sheet.appendRow(row);
+    result = 'APPENDED';
+  }
+
+  return ContentService.createTextOutput(result)
+    .setMimeType(ContentService.MimeType.TEXT);
+}

--- a/src/App.js
+++ b/src/App.js
@@ -34,6 +34,7 @@ import LoadingScreen   from './components/LoadingScreen';
 import NotificationBell from './components/NotificationBell';
 import SeleccionRol    from './screens/SeleccionRol';
 import CompletarDatosGoogle from './screens/CompletarDatosGoogle';
+import { useSyncClassToSheet } from './hooks/useSyncClassToSheet';
 
 const AppContainer = styled.div`
   display: flex;
@@ -57,6 +58,9 @@ const Layout = () => (
 function AppContent() {
   const location = useLocation();
   const [loading, setLoading] = useState(true);
+
+  // Example: sync a specific class to Google Sheets
+  useSyncClassToSheet('union123', 'assignment456');
 
   useEffect(() => {
     setLoading(true);

--- a/src/hooks/useSyncClassToSheet.js
+++ b/src/hooks/useSyncClassToSheet.js
@@ -1,0 +1,47 @@
+// src/hooks/useSyncClassToSheet.js
+// Hook to sync a Firestore class document with Google Sheets via webhook
+import { useEffect } from 'react';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { db } from '../firebase/firebaseConfig';
+
+const WEBHOOK_URL =
+  'https://script.google.com/macros/s/AKfycbxnWRLywG3iF9VhIg7J1JRpXoW3EXvJMs-mGeqbyfz4ELOSARLExBi71ok57Tsybxev/exec';
+const SHEET_SECRET = process.env.REACT_APP_SHEET_SECRET;
+
+export function useSyncClassToSheet(unionId, assignmentId) {
+  useEffect(() => {
+    if (!unionId || !assignmentId) return;
+    const ref = doc(db, 'clases_union', unionId, 'clases_asignadas', assignmentId);
+    const unsub = onSnapshot(ref, snap => {
+      if (!snap.exists()) return;
+      const data = snap.data();
+      if (data.estado !== 'aceptada') return;
+      const payload = {
+        secret: SHEET_SECRET,
+        idClase: assignmentId,
+        emailProfesor: data.emailProfesor,
+        nombreProfesor: data.nombreProfesor,
+        emailAlumno: data.emailAlumno,
+        nombreAlumno: data.nombreAlumno,
+        curso: data.curso,
+        asignatura: data.asignatura,
+        ciudad: data.ciudad,
+        fecha: data.fecha,
+        duracion: data.duracion,
+        modalidad: data.modalidad,
+        numeroAlumnos: data.numeroAlumnos,
+        precioTotalPadres: data.precioTotalPadres,
+        precioTotalProfesor: data.precioTotalProfesor,
+        beneficio: (data.precioTotalPadres || 0) - (data.precioTotalProfesor || 0),
+      };
+
+      fetch(WEBHOOK_URL, {
+        method: 'POST',
+        mode: 'no-cors',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      }).catch(err => console.error('Sheet sync error', err));
+    });
+    return () => unsub();
+  }, [unionId, assignmentId]);
+}


### PR DESCRIPTION
## Summary
- refine Apps Script `doPost` to handle numeric values and reduce range size
- allow `useSyncClassToSheet` hook to send no‑CORS POST requests
- document use of no‑CORS in README

## Testing
- `npm test --silent` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686e9cef838c832bbe69ada1f3e2f6ef