### PR TITLE
Fix unused import warning

### DIFF
--- a/src/screens/SerProfesor.jsx
+++ b/src/screens/SerProfesor.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled, { keyframes } from 'styled-components';
-import profesoresImg from '../assets/profesores.png';
 import serProfeImg from '../assets/serprofe.png';
 import { useNavigate } from 'react-router-dom';
 


### PR DESCRIPTION
## Summary
- remove unused profesores image import in `SerProfesor.jsx`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ba8138b74832b9f834bc0dfa11475