### PR TITLE
Add floating label styling to some forms

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import './styles/global.css';
+import './styles/forms.css';
 import App from './App';
 import { NotificationProvider } from './NotificationContext';
 import { NotificationsProvider } from './NotificationsStore';

--- a/src/screens/SignUpAlumno.jsx
+++ b/src/screens/SignUpAlumno.jsx
@@ -404,77 +404,98 @@ export default function SignUpAlumno() {
 
         <FormGrid>
           <Field>
-            <label>E-mail</label>
-          <input className="form-control"
-            type="email"
-            value={email}
-            onChange={e => {
-              setEmail(e.target.value);
-              setEmailError('');
-            }}
-            placeholder="tucorreo@ejemplo.com"
-          />
-          {emailError && <ErrorText>{emailError}</ErrorText>}
-        </Field>
-          <Field>
-            <label>Contraseña</label>
-            <input className="form-control"
-              type="password"
-              value={password}
-              onChange={e => setPassword(e.target.value)}
-              placeholder="Contraseña"
-            />
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="email"
+                value={email}
+                onChange={e => {
+                  setEmail(e.target.value);
+                  setEmailError('');
+                }}
+                placeholder=" "
+              />
+              <label className="fl-label">E-mail</label>
+            </div>
+            {emailError && <ErrorText>{emailError}</ErrorText>}
           </Field>
           <Field>
-            <label>Repite Contraseña</label>
-            <input className="form-control"
-              type="password"
-              value={confirmPwd}
-              onChange={e => setConfirmPwd(e.target.value)}
-              placeholder="Repite contraseña"
-            />
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="password"
+                value={password}
+                onChange={e => setPassword(e.target.value)}
+                placeholder=" "
+              />
+              <label className="fl-label">Contraseña</label>
+            </div>
           </Field>
           <Field>
-            <label>Nombre</label>
-            <input className="form-control"
-              type="text"
-              value={nombre}
-              onChange={e => setNombre(e.target.value)}
-              placeholder="Tu nombre"
-            />
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="password"
+                value={confirmPwd}
+                onChange={e => setConfirmPwd(e.target.value)}
+                placeholder=" "
+              />
+              <label className="fl-label">Repite Contraseña</label>
+            </div>
           </Field>
           <Field>
-            <label>Apellidos</label>
-            <input className="form-control"
-              type="text"
-              value={apellido}
-              onChange={e => setApellido(e.target.value)}
-              placeholder="Tus apellidos"
-            />
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="text"
+                value={nombre}
+                onChange={e => setNombre(e.target.value)}
+                placeholder=" "
+              />
+              <label className="fl-label">Nombre</label>
+            </div>
           </Field>
           <Field>
-            <label>Teléfono</label>
-            <input className="form-control"
-              type="tel"
-              value={telefono}
-              onChange={e => {
-                setTelefono(e.target.value);
-                setTelefonoError('');
-              }}
-              placeholder="Ej. +34 600 123 456"
-            />
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="text"
+                value={apellido}
+                onChange={e => setApellido(e.target.value)}
+                placeholder=" "
+              />
+              <label className="fl-label">Apellidos</label>
+            </div>
           </Field>
           <Field>
-            <label>Repite Teléfono</label>
-            <input className="form-control"
-              type="tel"
-              value={confirmTelefono}
-              onChange={e => {
-                setConfirmTelefono(e.target.value);
-                setTelefonoError('');
-              }}
-              placeholder="Confirma teléfono"
-            />
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="tel"
+                value={telefono}
+                onChange={e => {
+                  setTelefono(e.target.value);
+                  setTelefonoError('');
+                }}
+                placeholder=" "
+              />
+              <label className="fl-label">Teléfono</label>
+            </div>
+          </Field>
+          <Field>
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="tel"
+                value={confirmTelefono}
+                onChange={e => {
+                  setConfirmTelefono(e.target.value);
+                  setTelefonoError('');
+                }}
+                placeholder=" "
+              />
+              <label className="fl-label">Repite Teléfono</label>
+            </div>
             {telefonoError && <ErrorText>{telefonoError}</ErrorText>}
           </Field>
 
@@ -527,31 +548,42 @@ export default function SignUpAlumno() {
 
           {rolUser === 'alumno' ? (
             <Field style={{gridColumn:'1 / -1'}}>
-              <label>Fecha de Nacimiento</label>
-              <input className="form-control"
-                type="date"
-                value={fechaNac}
-                onChange={e=>setFechaNac(e.target.value)}
-              />
+              <div className="fl-field">
+                <input
+                  className="form-control fl-input"
+                  type="date"
+                  value={fechaNac}
+                  onChange={e=>setFechaNac(e.target.value)}
+                  placeholder=" "
+                />
+                <label className="fl-label">Fecha de Nacimiento</label>
+              </div>
             </Field>
           ) : (
             <>
               <Field>
-                <label>Nombre del Hijo</label>
-                <input className="form-control"
-                  type="text"
-                  value={nombreHijo}
-                  onChange={e=>setNombreHijo(e.target.value)}
-                  placeholder="Nombre completo"
-                />
+                <div className="fl-field">
+                  <input
+                    className="form-control fl-input"
+                    type="text"
+                    value={nombreHijo}
+                    onChange={e=>setNombreHijo(e.target.value)}
+                    placeholder=" "
+                  />
+                  <label className="fl-label">Nombre del Hijo</label>
+                </div>
               </Field>
               <Field>
-                <label>Fecha Nacimiento del Hijo</label>
-                <input className="form-control"
-                  type="date"
-                  value={fechaNacHijo}
-                  onChange={e=>setFechaNacHijo(e.target.value)}
-                />
+                <div className="fl-field">
+                  <input
+                    className="form-control fl-input"
+                    type="date"
+                    value={fechaNacHijo}
+                    onChange={e=>setFechaNacHijo(e.target.value)}
+                    placeholder=" "
+                  />
+                  <label className="fl-label">Fecha Nacimiento del Hijo</label>
+                </div>
               </Field>
               <p style={{gridColumn: '1 / -1', fontSize:'0.85rem', color:'#555'}}>
                 Podrás añadir más hijos desde la pestaña "Mi cuenta".

--- a/src/screens/SignUpProfesor.jsx
+++ b/src/screens/SignUpProfesor.jsx
@@ -318,78 +318,99 @@ export default function SignUpProfesor() {
         <Subtitle>¡Empieza hoy a compartir tu pasión por el conocimiento y transforma vidas!</Subtitle>
         <FormGrid>
           <Field>
-            <label>E-mail</label>
-          <input className="form-control"
-            type="email"
-            value={email}
-            onChange={e => {
-              setEmail(e.target.value);
-              setEmailError('');
-            }}
-            placeholder="tucorreo@ejemplo.com"
-          />
-          {emailError && <ErrorText>{emailError}</ErrorText>}
-        </Field>
-          <Field>
-            <label>Teléfono</label>
-            <input className="form-control"
-              type="tel"
-              value={telefono}
-              onChange={e => {
-                setTelefono(e.target.value);
-                setTelefonoError('');
-              }}
-              placeholder="Ej. +34 600 123 456"
-            />
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="email"
+                value={email}
+                onChange={e => {
+                  setEmail(e.target.value);
+                  setEmailError('');
+                }}
+                placeholder=" "
+              />
+              <label className="fl-label">E-mail</label>
+            </div>
+            {emailError && <ErrorText>{emailError}</ErrorText>}
           </Field>
           <Field>
-            <label>Repite Teléfono</label>
-            <input className="form-control"
-              type="tel"
-              value={confirmTelefono}
-              onChange={e => {
-                setConfirmTelefono(e.target.value);
-                setTelefonoError('');
-              }}
-              placeholder="Confirma teléfono"
-            />
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="tel"
+                value={telefono}
+                onChange={e => {
+                  setTelefono(e.target.value);
+                  setTelefonoError('');
+                }}
+                placeholder=" "
+              />
+              <label className="fl-label">Teléfono</label>
+            </div>
+          </Field>
+          <Field>
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="tel"
+                value={confirmTelefono}
+                onChange={e => {
+                  setConfirmTelefono(e.target.value);
+                  setTelefonoError('');
+                }}
+                placeholder=" "
+              />
+              <label className="fl-label">Repite Teléfono</label>
+            </div>
             {telefonoError && <ErrorText>{telefonoError}</ErrorText>}
           </Field>
           <Field>
-            <label>Contraseña</label>
-            <input className="form-control"
-              type="password"
-              value={password}
-              onChange={e => setPassword(e.target.value)}
-              placeholder="Contraseña"
-            />
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="password"
+                value={password}
+                onChange={e => setPassword(e.target.value)}
+                placeholder=" "
+              />
+              <label className="fl-label">Contraseña</label>
+            </div>
           </Field>
           <Field>
-            <label>Repite Contraseña</label>
-            <input className="form-control"
-              type="password"
-              value={confirmPassword}
-              onChange={e => setConfirm(e.target.value)}
-              placeholder="Repite la contraseña"
-            />
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="password"
+                value={confirmPassword}
+                onChange={e => setConfirm(e.target.value)}
+                placeholder=" "
+              />
+              <label className="fl-label">Repite Contraseña</label>
+            </div>
           </Field>
           <Field>
-            <label>Nombre</label>
-            <input className="form-control"
-              type="text"
-              value={nombre}
-              onChange={e => setNombre(e.target.value)}
-              placeholder="Tu nombre"
-            />
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="text"
+                value={nombre}
+                onChange={e => setNombre(e.target.value)}
+                placeholder=" "
+              />
+              <label className="fl-label">Nombre</label>
+            </div>
           </Field>
           <Field>
-            <label>Apellidos</label>
-            <input className="form-control"
-              type="text"
-              value={apellido}
-              onChange={e => setApellido(e.target.value)}
-              placeholder="Tus apellidos"
-            />
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="text"
+                value={apellido}
+                onChange={e => setApellido(e.target.value)}
+                placeholder=" "
+              />
+              <label className="fl-label">Apellidos</label>
+            </div>
           </Field>
           <Field style={{ gridColumn: '1 / -1' }} ref={ref}>
             <label>Ciudad</label>

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -1,0 +1,53 @@
+:root{
+  --green:#00A859; /* verde corporativo */
+  --bg-bubble:#E8F4FD;
+  --text:#333;
+  --radius:14px;
+  --transition:0.18s ease;
+  --label-small:0.75rem;
+  --label-normal:1rem;
+}
+
+.fl-field{
+  position:relative;
+  margin:1rem 0;
+}
+
+.fl-input{
+  width:100%;
+  padding:1.1rem 1rem 0.6rem;
+  border:1px solid transparent;
+  border-radius:var(--radius);
+  background:var(--bg-bubble);
+  font-size:1rem;
+  color:var(--text);
+  transition:border-color var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.fl-input:focus{
+  outline:none;
+  border-color:var(--green);
+  box-shadow:0 0 0 3px color-mix(in srgb, var(--green) 20%, transparent);
+  background:#fff;
+}
+
+/* Label flotante */
+.fl-label{
+  position:absolute;
+  top:50%;
+  left:1rem;
+  transform:translateY(-50%);
+  pointer-events:none;
+  color:#6b6b6b;
+  font-size:var(--label-normal);
+  transition:transform var(--transition), font-size var(--transition), color var(--transition), top var(--transition);
+}
+
+/* cuando hay texto o foco, el label sube */
+.fl-input:focus + .fl-label,
+.fl-input:not(:placeholder-shown) + .fl-label{
+  top:0.45rem;
+  transform:none;
+  font-size:var(--label-small);
+  color:var(--green);
+}


### PR DESCRIPTION
## Summary
- import new floating-form styles in `index.js`
- apply floating label markup to several fields in `SignUpAlumno.jsx` and `SignUpProfesor.jsx`
- add shared CSS for floating inputs

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687f65473270832b9e6c9ace0c06a5d1