### PR TITLE
Add auth emulator configuration

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -22,6 +22,9 @@
     "firestore": {
       "port": 8080
     },
+    "auth": {
+      "port": 9099
+    },
     "ui": {
       "enabled": true,
       "port": 4001


### PR DESCRIPTION
## Summary
- configure Firebase auth emulator on port 9099
- start emulators for functions, firestore, and auth during testing

## Testing
- `npx -y firebase-tools emulators:start --only functions,firestore,auth`

------
https://chatgpt.com/codex/tasks/task_e_687fe3332c6c832b941709e4361c517e