### PR TITLE
Use environment variables for Gmail credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,5 +114,18 @@ functionsV1.auth.user().onCreate(async (user) => {
 });
 ```
 
-The transporter is configured with the account `alvaro@studentproject.es`. Remember to deploy the functions after any change with `npm run deploy` in the `functions` folder.
+The transporter now reads its credentials from the environment variables `EMAIL_USER` and `EMAIL_PASS`. Set these using `firebase functions:config:set` before deploying:
+
+```
+firebase functions:config:set email.user="yourEmail" email.pass="yourPassword"
+```
+
+For local development with the Emulator Suite, create a `.env` file inside the `functions` directory containing the same variables:
+
+```
+EMAIL_USER=yourEmail
+EMAIL_PASS=yourPassword
+```
+
+Remember to deploy the functions after any change with `npm run deploy` in the `functions` folder.
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -8,8 +8,8 @@ functions.setGlobalOptions({ maxInstances: 10 });
 const transporter = nodemailer.createTransport({
   service: 'gmail',
   auth: {
-    user: 'alvaro@studentproject.es',
-    pass: 'ibmf zall dcqj vbuw',
+    user: process.env.EMAIL_USER,
+    pass: process.env.EMAIL_PASS,
   },
 });
 


### PR DESCRIPTION
## Summary
- reference `EMAIL_USER` and `EMAIL_PASS` in Cloud Function
- document how to configure these credentials for deploys and the emulator

## Testing
- `npm test -- -w 1 --runInBand` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff8dae9bc832b8f9b2c7fd5153764