### PR TITLE
Update Cloud Function Node version

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -16,7 +16,7 @@
         "firebase-functions-test": "^3.1.0"
       },
       "engines": {
-        "node": "22"
+        "node": "20"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -10,7 +10,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "22"
+    "node": "20"
   },
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
## Summary
- lower Node engine requirement for Firebase functions from v22 to v20
- reinstall dependencies
- attempt to redeploy functions (fails without Firebase authentication)

## Testing
- `npm install`
- `npm install -g firebase-tools`
- `npm run deploy` *(fails: Failed to authenticate)*
- `firebase login --no-localhost` *(fails: unexpected error)*

------
https://chatgpt.com/codex/tasks/task_e_687ffba56784832bbabb02177852a6af