### PR TITLE
Fix missing brace in Clases.jsx

### DIFF
--- a/src/screens/alumno/acciones/Clases.jsx
+++ b/src/screens/alumno/acciones/Clases.jsx
@@ -504,7 +504,7 @@ export default function Clases() {
                   <RejectButton onClick={() => rejectAssignment(p)} disabled={processingIds.has(p.id)}>Cancelar</RejectButton>
                 </div>
               </Card>
-            ))
+            ))}
             {solicitudes.map(s => {
               const estado = s.estado === 'pendiente'
                 ? (s.offers === 0 ? 'En búsqueda de profesor' : 'En selección de profesor')


### PR DESCRIPTION
## Summary
- close pendingAssignments map expression in `Clases` component

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6881254dc208832baa2a3c9bd57b0fe9