### PR TITLE
Update class workflow statuses

### DIFF
--- a/src/screens/alumno/acciones/Clases.jsx
+++ b/src/screens/alumno/acciones/Clases.jsx
@@ -218,12 +218,12 @@ export default function Clases() {
       }
       setSolicitudes(data);
       // Load pending assignments awaiting student confirmation
-      let q2 = query(collection(db, 'registro_clases'), where('alumnoId', '==', u.uid), where('estado', '==', 'pendiente_alumno'));
+      let q2 = query(collection(db, 'registro_clases'), where('alumnoId', '==', u.uid), where('estado', '==', 'espera_alumno'));
       if (selectedChild) {
         q2 = query(collection(db, 'registro_clases'),
                   where('alumnoId', '==', u.uid),
                   where('hijoId', '==', selectedChild.id),
-                  where('estado', '==', 'pendiente_alumno'));
+                  where('estado', '==', 'espera_alumno'));
       }
       const snap2 = await getDocs(q2);
       setPendingAssignments(snap2.docs.map(d => ({ id: d.id, ...d.data() })));

--- a/src/screens/profesor/acciones/SolicitudesAsignacion.jsx
+++ b/src/screens/profesor/acciones/SolicitudesAsignacion.jsx
@@ -70,7 +70,7 @@ export default function SolicitudesAsignacion() {
     setProcessing(prev => new Set(prev).add(rec.id));
     try {
       await acceptClassByTeacher(rec.id, rec.studentEmail, rec.alumnoNombre);
-      setRecords(rs => rs.map(r => r.id === rec.id ? { ...r, estado: 'pendiente_alumno' } : r));
+      setRecords(rs => rs.map(r => r.id === rec.id ? { ...r, estado: 'espera_alumno' } : r));
     } finally {
       setProcessing(prev => { const s = new Set(prev); s.delete(rec.id); return s; });
     }
@@ -99,9 +99,9 @@ export default function SolicitudesAsignacion() {
             <InfoGrid>
               <div><strong>Alumno:</strong> {r.alumnoNombre}</div>
               <div><strong>Asignaturas:</strong> {r.classInfo?.asignaturas ? r.classInfo.asignaturas.join(', ') : r.classInfo?.asignatura}</div>
-              <div><strong>Estado:</strong> {r.estado === 'pendiente_profesor' ? 'Pendiente tu aceptación' : 'Esperando al alumno'}</div>
+              <div><strong>Estado:</strong> {r.estado === 'espera_profesor' ? 'Pendiente tu aceptación' : 'Esperando al alumno'}</div>
             </InfoGrid>
-            {r.estado === 'pendiente_profesor' && (
+            {r.estado === 'espera_profesor' && (
               <div>
                 <Button onClick={() => handleAccept(r)} disabled={processing.has(r.id)}>Aceptar</Button>{' '}
                 <CancelButton onClick={() => handleCancel(r)} disabled={processing.has(r.id)}>Cancelar</CancelButton>

--- a/src/utils/classWorkflow.js
+++ b/src/utils/classWorkflow.js
@@ -12,14 +12,14 @@ export async function registerPendingClass({ classId, offer, alumnoId, alumnoNom
     profesorNombre: offer.profesorNombre,
     padreNombre: padreNombre || null,
     hijoId: hijoId || null,
-    estado: 'pendiente_profesor',
+    estado: 'espera_profesor',
     createdAt: serverTimestamp(),
   });
 }
 
 export async function acceptClassByTeacher(recordId, studentEmail, studentName) {
   const ref = doc(db, 'registro_clases', recordId);
-  await updateDoc(ref, { estado: 'pendiente_alumno', acceptedByTeacher: serverTimestamp() });
+  await updateDoc(ref, { estado: 'espera_alumno', acceptedByTeacher: serverTimestamp() });
   await sendAssignmentEmails({
     studentEmail,
     studentName,
@@ -39,6 +39,7 @@ export async function acceptClassByStudent(recordId, data) {
     profesorNombre: data.profesorNombre,
     padreNombre: data.padreNombre || null,
     hijoId: data.hijoId || null,
+    estado: 'clase_formada',
     createdAt: serverTimestamp(),
   });
 }


### PR DESCRIPTION
## Summary
- rename pending states to `espera_profesor`/`espera_alumno`
- mark final union creation as `clase_formada`
- adjust teacher and student screens to match new states

## Testing
- `npm test --silent --yes` *(fails: No tests found)*
- `cd functions && npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6881283df6f0832bb3487075d677f47b