### PR TITLE
Implement class status workflow

### DIFF
--- a/src/screens/alumno/acciones/Clases.jsx
+++ b/src/screens/alumno/acciones/Clases.jsx
@@ -354,7 +354,8 @@ export default function Clases() {
     if (processingIds.has(rec.id)) return;
     setProcessingIds(prev => new Set(prev).add(rec.id));
     try {
-      await acceptClassByStudent(rec.id, rec);
+      const emailUser = auth.currentUser ? auth.currentUser.email : '';
+      await acceptClassByStudent(rec.id, { ...rec, studentEmail: emailUser });
       setPendingAssignments(pa => pa.filter(r => r.id !== rec.id));
     } finally {
       setProcessingIds(prev => { const s = new Set(prev); s.delete(rec.id); return s; });

--- a/src/utils/classWorkflow.js
+++ b/src/utils/classWorkflow.js
@@ -42,6 +42,12 @@ export async function acceptClassByStudent(recordId, data) {
     estado: 'clase_formada',
     createdAt: serverTimestamp(),
   });
+  await sendAssignmentEmails({
+    studentEmail: data.studentEmail,
+    studentName: data.alumnoNombre,
+    teacherName: data.profesorNombre,
+    recipient: 'both',
+  });
 }
 
 export async function rejectPendingClass(recordId) {


### PR DESCRIPTION
## Summary
- add REGISTRY_SHEET constant and `fetchRegistroClases` to read `registro_clases`
- preserve state when fetching classes and send emails when transitioning to `clase_formada`
- notify parent/student when forming a class from the React workflow

## Testing
- `npm test --silent`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68812e97684c832ba4748ee8c7ada259