### PR TITLE
Fix JSX closing brace in Clases component

### DIFF
--- a/src/screens/alumno/acciones/Clases.jsx
+++ b/src/screens/alumno/acciones/Clases.jsx
@@ -534,10 +534,10 @@ export default function Clases() {
                   </InfoGrid>
                 </Card>
               );
-            })
-            </>
-          )
-        )}
+              })}
+              </>
+            )
+          )}
       </Container>
     </Page>
   );


### PR DESCRIPTION
## Summary
- close the `solicitudes.map` JSX expression properly

## Testing
- `node - <<'EOF'
const fs=require('fs');
const parser=require('@babel/parser');
const code=fs.readFileSync('src/screens/alumno/acciones/Clases.jsx','utf8');
parser.parse(code,{sourceType:'module',plugins:['jsx']});
console.log("parse ok");
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68815501aa18832baa62ef6d2ebc773c