### PR TITLE
Integrate welcome email via Node server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 REACT_APP_SHEET_SECRET=
 EMAIL_USER=alvaro@studentproject.es
 EMAIL_PASS=ibmf zall dcqj vbuw
+REACT_APP_WELCOME_API=http://localhost:3001/send-email

--- a/README.md
+++ b/README.md
@@ -170,6 +170,23 @@ Another option is to send the welcome message through the standalone server insi
    ```
    The server uses Nodemailer with the credentials from `.env` to send the welcome email.
 
+## Running React with the Node server
+
+To work locally with both the frontend and the `node-server` you can run each one in its own terminal:
+
+1. **Start the API server**
+   ```bash
+   cd node-server
+   npm start
+   ```
+
+2. **Start the React app** from the project root:
+   ```bash
+   npm start
+   ```
+
+The client reads the `REACT_APP_WELCOME_API` variable from `.env` (default `http://localhost:3001/send-email`) and sends a request after a user signs up. With CORS enabled on the server both applications work together without extra configuration.
+
 ## Firebase Emulator Suite
 
 Start the local emulators to test Firestore, Authentication and Cloud Functions:

--- a/node-server/README.md
+++ b/node-server/README.md
@@ -23,6 +23,7 @@ npm start
 ```
 
 El servidor se inicia por defecto en el puerto `3001`. Puedes cambiarlo definiendo la variable `PORT` en el archivo `.env`.
+El middleware de **CORS** viene activado para aceptar peticiones del cliente de React (por defecto en `http://localhost:3000`).
 
 ## Uso del endpoint
 

--- a/node-server/index.js
+++ b/node-server/index.js
@@ -2,8 +2,10 @@ require('dotenv').config();
 
 const express = require('express');
 const nodemailer = require('nodemailer');
+const cors = require('cors');
 
 const app = express();
+app.use(cors());
 app.use(express.json());
 
 const transporter = nodemailer.createTransport({

--- a/node-server/package-lock.json
+++ b/node-server/package-lock.json
@@ -8,6 +8,7 @@
       "name": "studentproject-mailer",
       "version": "1.0.0",
       "dependencies": {
+        "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "nodemailer": "^6.9.13"
@@ -208,6 +209,19 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -798,6 +812,15 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/node-server/package.json
+++ b/node-server/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "nodemailer": "^6.9.13"
+    "nodemailer": "^6.9.13",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "nodemon": "^3.0.3"

--- a/src/screens/SignUpAlumno.jsx
+++ b/src/screens/SignUpAlumno.jsx
@@ -4,6 +4,7 @@ import styled, { keyframes } from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import { useNotification } from "../NotificationContext";
 import { isValidEmail } from '../utils/validateEmail';
+import { sendWelcomeEmail } from '../utils/email';
 
 // Firebase (inicializado en firebaseConfig.js)
 import { auth, db } from '../firebase/firebaseConfig';
@@ -376,6 +377,7 @@ export default function SignUpAlumno() {
         ];
       }
       await setDoc(doc(db, 'usuarios', user.uid), data);
+      await sendWelcomeEmail({ email, name: nombre });
       show('Alumno registrado con éxito', 'success');
       navigate('/');
     } catch (err) {

--- a/src/screens/SignUpProfesor.jsx
+++ b/src/screens/SignUpProfesor.jsx
@@ -4,6 +4,7 @@ import styled, { keyframes } from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import { useNotification } from "../NotificationContext";
 import { isValidEmail } from '../utils/validateEmail';
+import { sendWelcomeEmail } from '../utils/email';
 
 // Firebase (inicializado en firebaseConfig.js)
 import { auth, db } from '../firebase/firebaseConfig';
@@ -300,6 +301,7 @@ export default function SignUpProfesor() {
         rol: 'profesor',
         createdAt: new Date()
       });
+      await sendWelcomeEmail({ email, name: nombre });
       show('Profesor registrado con éxito', 'success');
       navigate('/');
     } catch (err) {

--- a/src/utils/email.js
+++ b/src/utils/email.js
@@ -10,3 +10,15 @@ export async function sendAssignmentEmails({ teacherEmail, teacherName, studentE
     console.error('Failed to send emails', err);
   }
 }
+
+export async function sendWelcomeEmail({ email, name }) {
+  try {
+    await fetch(process.env.REACT_APP_WELCOME_API || 'http://localhost:3001/send-email', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, name })
+    });
+  } catch (err) {
+    console.error('Failed to send welcome email', err);
+  }
+}


### PR DESCRIPTION
## Summary
- add `sendWelcomeEmail` helper and call it after user sign up
- enable CORS on the Node server
- document how to run React with the Node backend
- mention CORS usage in node-server README
- include welcome API variable in `.env.example`

## Testing
- `npm test -- -u`


------
https://chatgpt.com/codex/tasks/task_e_6882a4a76c04832b888783a0df18c93c