### PR TITLE
Add firebase admin credential path support

### DIFF
--- a/node-server/.env-example
+++ b/node-server/.env-example
@@ -3,3 +3,5 @@ EMAIL_PASS=zvet uxtn ocfd wvpj
 PORT=3001
 JWT_SECRET=changeThisSecret
 RESET_BASE_URL=http://localhost:3000/reset-password
+# Path to your Firebase service account JSON
+GOOGLE_APPLICATION_CREDENTIALS=service-account.json

--- a/node-server/README.md
+++ b/node-server/README.md
@@ -10,15 +10,19 @@ Este servidor Node.js expone diferentes endpoints para enviar correos desde la p
    ```
 2. Copia el archivo de ejemplo `.env-example` a `.env` y edítalo:
    ```bash
-   cp .env-example .env
-   # Modifica EMAIL_USER y EMAIL_PASS si cambian las credenciales
-   # Establece JWT_SECRET y RESET_BASE_URL para los correos de restablecimiento
-   # y proporciona las credenciales de Firebase para `firebase-admin`.
-  ```
+    cp .env-example .env
+    # Modifica EMAIL_USER y EMAIL_PASS si cambian las credenciales
+    # Establece JWT_SECRET y RESET_BASE_URL para los correos de restablecimiento
+    # Especifica la ruta del JSON de la cuenta de servicio con
+    # GOOGLE_APPLICATION_CREDENTIALS
+    ```
 
-   * `JWT_SECRET` puede ser cualquier cadena aleatoria que solo tú conozcas. El
-     servidor la utiliza para firmar los tokens de restablecimiento. Cuanto más
-     larga y compleja sea, mejor.
+  * `JWT_SECRET` puede ser cualquier cadena aleatoria que solo tú conozcas. El
+    servidor la utiliza para firmar los tokens de restablecimiento. Cuanto más
+    larga y compleja sea, mejor.
+  * `GOOGLE_APPLICATION_CREDENTIALS` debe apuntar al archivo JSON de la cuenta
+    de servicio de Firebase. Este archivo se obtiene desde la consola de
+    Firebase y permite que el servidor utilice la API de administración.
 
 ## Ejecutar el servidor
 

--- a/node-server/index.js
+++ b/node-server/index.js
@@ -10,9 +10,17 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
-admin.initializeApp({
-  credential: admin.credential.applicationDefault(),
-});
+// Allow setting a service account key via env. Otherwise use application default
+const credsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+if (credsPath) {
+  admin.initializeApp({
+    credential: admin.credential.cert(require(credsPath)),
+  });
+} else {
+  admin.initializeApp({
+    credential: admin.credential.applicationDefault(),
+  });
+}
 
 const transporter = nodemailer.createTransport({
   service: 'gmail',


### PR DESCRIPTION
## Summary
- support service account credentials via `GOOGLE_APPLICATION_CREDENTIALS`
- document new variable and setup steps

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6882b92531e0832b9ce2f910e779c4e5