### PR TITLE
Implement email verification and enhanced sign-up forms

### DIFF
--- a/node-server/index.js
+++ b/node-server/index.js
@@ -72,6 +72,25 @@ app.post('/send-email', async (req, res) => {
   }
 });
 
+app.post('/send-verification-code', async (req, res) => {
+  const { email, code } = req.body;
+  if (!email || !code) {
+    return res.status(400).json({ error: 'Datos incompletos' });
+  }
+  try {
+    await transporter.sendMail({
+      from: `"Student Project" <${process.env.EMAIL_USER || 'alvaro@studentproject.es'}>`,
+      to: email,
+      subject: 'Código de verificación',
+      html: `<p>Tu código de verificación es: <strong>${code}</strong></p>`
+    });
+    res.json({ message: 'Código enviado' });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Error enviando código' });
+  }
+});
+
 // Append user data to Google Sheets
 app.post('/sheet/user', async (req, res) => {
   const d = req.body || {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-helmet": "^6.1.0",
+        "react-phone-input-2": "^2.15.0",
         "react-router-dom": "^7.5.2",
         "react-scripts": "5.0.1",
         "recharts": "^2.15.3",
@@ -6871,6 +6872,12 @@
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "license": "MIT"
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/clean-css": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
@@ -12767,10 +12774,22 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "license": "MIT"
     },
+    "node_modules/lodash.reduce": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "integrity": "sha512-6raRe2vxCYBhpBu+B+TtNGUzah+hQjVdu3E17wfusjyrXBka2nBS8OH/gjVZ5PvHOhWmIZTYri09Z6n/QfnNMw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.startswith": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.startswith/-/lodash.startswith-4.2.1.tgz",
+      "integrity": "sha512-XClYR1h4/fJ7H+mmCKppbiBmljN/nGs73iq2SjCT9SF4CBPoUHzLvWmH1GtZMhMBZSiRkHXfeA2RY1eIlJ75ww==",
       "license": "MIT"
     },
     "node_modules/lodash.uniq": {
@@ -15650,6 +15669,24 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
+    },
+    "node_modules/react-phone-input-2": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/react-phone-input-2/-/react-phone-input-2-2.15.1.tgz",
+      "integrity": "sha512-W03abwhXcwUoq+vUFvC6ch2+LJYMN8qSOiO889UH6S7SyMCQvox/LF3QWt+cZagZrRdi5z2ON3omnjoCUmlaYw==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.2.6",
+        "lodash.debounce": "^4.0.8",
+        "lodash.memoize": "^4.1.2",
+        "lodash.reduce": "^4.6.0",
+        "lodash.startswith": "^4.2.1",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^16.12.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0",
+        "react-dom": "^16.12.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-scripts": "5.0.1",
     "recharts": "^2.15.3",
     "styled-components": "^6.1.17",
+    "react-phone-input-2": "^2.15.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/utils/email.js
+++ b/src/utils/email.js
@@ -22,3 +22,16 @@ export async function sendWelcomeEmail({ email, name }) {
     console.error('Failed to send welcome email', err);
   }
 }
+
+export async function sendVerificationCode({ email, code }) {
+  try {
+    const base = (process.env.REACT_APP_WELCOME_API || 'http://localhost:3001/send-email').replace('/send-email','');
+    await fetch(`${base}/send-verification-code`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, code })
+    });
+  } catch (err) {
+    console.error('Failed to send verification code', err);
+  }
+}


### PR DESCRIPTION
## Summary
- add endpoint to send email verification code
- support verification API call from React
- integrate email verification and salutation fields in tutor & teacher sign-up
- add phone input with international prefixes using `react-phone-input-2`
- restructure parent registration to separate tutor and student info

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a249c971c832bb14c3502c5b1690e