### PR TITLE
Update class views to use tabs

### DIFF
--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1rem;
+  border-bottom: 2px solid #e0e0e0;
+`;
+
+const TabButton = styled.button`
+  background: none;
+  border: none;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  cursor: pointer;
+  color: ${({ active }) => (active ? '#046654' : '#666')};
+  border-bottom: ${({ active }) => (active ? '3px solid #046654' : '3px solid transparent')};
+  font-weight: ${({ active }) => (active ? '700' : '500')};
+`;
+
+export default function Tabs({ tabs, active, onChange }) {
+  return (
+    <Container>
+      {tabs.map(tab => (
+        <TabButton key={tab.value} active={tab.value === active} onClick={() => onChange(tab.value)}>
+          {tab.label}
+        </TabButton>
+      ))}
+    </Container>
+  );
+}

--- a/src/screens/alumno/acciones/Clases.jsx
+++ b/src/screens/alumno/acciones/Clases.jsx
@@ -6,7 +6,7 @@ import { useChild } from '../../../ChildContext';
 import LoadingScreen from '../../../components/LoadingScreen';
 import Card from '../../../components/CommonCard';
 import InfoGrid from '../../../components/InfoGrid';
-import ToggleSwitch from "../../../components/ToggleSwitch";
+import Tabs from "../../../components/Tabs";
 import { auth, db } from '../../../firebase/firebaseConfig';
 import {
   collection,
@@ -401,7 +401,14 @@ export default function Clases() {
     <Page>
       <Container>
         <Title>Mis Clases & Solicitudes</Title>
-        <ToggleSwitch leftLabel="Mis clases" rightLabel="Mis solicitudes" value={view === "clases" ? "left" : "right"} onChange={(val) => setView(val === "left" ? "clases" : "solicitudes")}/>
+        <Tabs
+          tabs={[
+            { label: 'Mis clases', value: 'clases' },
+            { label: 'Mis solicitudes', value: 'solicitudes' },
+          ]}
+          active={view}
+          onChange={setView}
+        />
 
         {view === 'clases' ? (
           <>

--- a/src/screens/profesor/acciones/Clases.jsx
+++ b/src/screens/profesor/acciones/Clases.jsx
@@ -5,7 +5,7 @@ import { useSearchParams } from 'react-router-dom';
 import LoadingScreen from '../../../components/LoadingScreen';
 import Card from '../../../components/CommonCard';
 import InfoGrid from '../../../components/InfoGrid';
-import ToggleSwitch from "../../../components/ToggleSwitch";
+import Tabs from "../../../components/Tabs";
 import { auth, db } from '../../../firebase/firebaseConfig';
 import { useNotification } from '../../../NotificationContext';
 import {
@@ -365,7 +365,14 @@ export default function ClasesProfesor() {
     <Page>
       <Container>
         <Title>Mis Clases & Ofertas</Title>
-        <ToggleSwitch leftLabel="Mis clases" rightLabel="Mis ofertas" value={view === "clases" ? "left" : "right"} onChange={(val) => setView(val === "left" ? "clases" : "ofertas")}/>
+        <Tabs
+          tabs={[
+            { label: 'Mis clases', value: 'clases' },
+            { label: 'Mis ofertas', value: 'ofertas' },
+          ]}
+          active={view}
+          onChange={setView}
+        />
 
         {view === 'clases' ? (
           <>


### PR DESCRIPTION
## Summary
- add reusable `Tabs` component for simple tab navigation
- use the new tabs in student's and teacher's class screens

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a2501bce4832b815f3141d1e83105