### PR TITLE
Fix SignUpProfesor JSX tag mismatch

### DIFF
--- a/src/screens/SignUpProfesor.jsx
+++ b/src/screens/SignUpProfesor.jsx
@@ -396,8 +396,6 @@ export default function SignUpProfesor() {
             />
             {telefonoError && <ErrorText>{telefonoError}</ErrorText>}
           </Field>
-            {telefonoError && <ErrorText>{telefonoError}</ErrorText>}
-          </Field>
           <Field>
             <div className="fl-field">
               <input


### PR DESCRIPTION
## Summary
- fix unbalanced `<Field>` closing tag in `SignUpProfesor.jsx`
- install dependencies and run tests

## Testing
- `CI=true npm test --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a31e5948c832b952403c3116675f9