### PR TITLE
Rename parent role and children field

### DIFF
--- a/node-server/README.md
+++ b/node-server/README.md
@@ -101,7 +101,7 @@ y debes colocarlo manualmente en la carpeta `node-server`.
   POST http://localhost:3001/sheet/user
   {
     "id": "uidFirebase",
-    "rol": "profesor" | "padre",
+    "rol": "profesor" | "tutor",
     "nombre": "Nombre",
     "apellidos": "Apellidos",
     "email": "correo@ejemplo.com",

--- a/node-server/index.js
+++ b/node-server/index.js
@@ -113,7 +113,7 @@ app.post('/sheet/user', async (req, res) => {
         d.job,
         d.iban,
       ]);
-    } else if (d.rol === 'padre') {
+    } else if (d.rol === 'tutor') {
       await appendRow('alumnos', [
         d.id,
         'P',

--- a/src/App.js
+++ b/src/App.js
@@ -22,7 +22,7 @@ import QuienesSomos    from './screens/QuienesSomos';
 import Contacto        from './screens/Contacto';
 import InicioSesion    from './screens/InicioSesion';
 import SignUpProfesor  from './screens/SignUpProfesor';
-import SignUpPadre     from './screens/SignUpPadre';
+import SignUpTutor     from './screens/SignUpTutor';
 import PanelProfesor   from './screens/profesor/PanelProfesor';
 import PanelAlumno     from './screens/alumno/PanelAlumno';
 import PanelAdmin      from './screens/admin/PanelAdmin';
@@ -75,7 +75,7 @@ function AppContent() {
       <Routes>
           {/* Sin Navbar/Footer */}
           <Route path="/alta-profesor" element={<SignUpProfesor />} />
-          <Route path="/alta-padre"    element={<SignUpPadre />} />
+          <Route path="/alta-tutor"    element={<SignUpTutor />} />
           <Route path="/inicio"        element={<InicioSesion />} />
           <Route path="/seleccion-rol" element={<SeleccionRol />} />
           <Route path="/google-datos" element={<CompletarDatosGoogle />} />
@@ -92,11 +92,11 @@ function AppContent() {
             {/* Ruta de perfil con parámetro userId */}
             <Route path="/perfil/:userId"       element={<Perfil />} />
 
-            <Route element={<RequireAuth allowedRoles={['padre','admin']} />}>
-              <Route path="/alumno"               element={<PanelAlumno />} />
-              <Route path="/alumno/nueva-clase"   element={<NuevaClase />} />
-              <Route path="/alumno/clases"        element={<Clases />} />
-              <Route path="/alumno/calendario"    element={<CalendarioA />} />
+            <Route element={<RequireAuth allowedRoles={['tutor','admin']} />}>
+              <Route path="/tutor"               element={<PanelAlumno />} />
+              <Route path="/tutor/nueva-clase"   element={<NuevaClase />} />
+              <Route path="/tutor/clases"        element={<Clases />} />
+              <Route path="/tutor/calendario"    element={<CalendarioA />} />
               <Route path="/profesor/mis-profesores" element={<MisProfesores />} />
             </Route>
 

--- a/src/ChildContext.js
+++ b/src/ChildContext.js
@@ -9,15 +9,15 @@ export const ChildProvider = ({ children }) => {
   const [selectedChild, setSelectedChild] = useState(null);
 
   useEffect(() => {
-    if (userData?.rol === 'padre') {
-      const hijos = (userData.hijos || []).filter(h => !h.disabled);
-      setChildList(hijos);
+    if (userData?.rol === 'tutor') {
+      const alumnos = (userData.alumnos || []).filter(h => !h.disabled);
+      setChildList(alumnos);
       setSelectedChild(prev => {
-        if (prev && hijos.some(h => h.id === prev.id)) {
+        if (prev && alumnos.some(h => h.id === prev.id)) {
           return prev;
         }
-        if (hijos.length === 1) {
-          return hijos[0];
+        if (alumnos.length === 1) {
+          return alumnos[0];
         }
         return null;
       });

--- a/src/components/AddChildModal.jsx
+++ b/src/components/AddChildModal.jsx
@@ -86,7 +86,7 @@ export default function AddChildModal({ open, onClose }) {
       photoURL: userData?.photoURL || auth.currentUser.photoURL || ''
     };
     const nuevos = [...childList, nuevo];
-    await updateDoc(doc(db, 'usuarios', auth.currentUser.uid), { hijos: nuevos });
+    await updateDoc(doc(db, 'usuarios', auth.currentUser.uid), { alumnos: nuevos });
     setChildList(nuevos.filter(c => !c.disabled));
     setSelectedChild(nuevo);
     setName('');

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -425,7 +425,7 @@ export default function Navbar() {
       } else if (rol === 'profesor') {
         navigate('/profesor');
       } else {
-        navigate('/alumno');
+        navigate('/tutor');
       }
       setLoginEmail('');
       setLoginPassword('');
@@ -452,7 +452,7 @@ export default function Navbar() {
         const rol = snap.data().rol;
         if (rol === 'admin') navigate('/admin');
         else if (rol === 'profesor') navigate('/profesor');
-        else navigate('/alumno');
+        else navigate('/tutor');
       } else {
         await setDoc(userRef, { photoURL: user.photoURL }, { merge: true });
         navigate('/seleccion-rol');
@@ -473,13 +473,13 @@ export default function Navbar() {
       ? '/admin'
       : userData?.rol === 'profesor'
       ? '/profesor'
-      : '/alumno';
+      : '/tutor';
   const panelText =
     userData?.rol === 'admin'
       ? 'Panel Admin'
       : userData?.rol === 'profesor'
       ? 'Panel Profesor/a'
-      : 'Panel Alumno/a';
+      : 'Panel Tutor/a';
 
   return (
     <>

--- a/src/components/RedirectLoggedIn.jsx
+++ b/src/components/RedirectLoggedIn.jsx
@@ -13,7 +13,7 @@ export default function RedirectLoggedIn() {
         ? '/admin'
         : userData.rol === 'profesor'
         ? '/profesor'
-        : '/alumno';
+        : '/tutor';
     return <Navigate to={target} replace />;
   }
 

--- a/src/screens/Alta.jsx
+++ b/src/screens/Alta.jsx
@@ -115,7 +115,7 @@ const Alta = () => (
           <CardDesc>
             Crea tu cuenta de tutor y te ayudaremos a encontrar al profesor ideal para tu hijo.
           </CardDesc>
-          <CardButton to="/alta-padre">
+          <CardButton to="/alta-tutor">
             Soy tutor
           </CardButton>
         </CardContent>

--- a/src/screens/CompletarDatosGoogle.jsx
+++ b/src/screens/CompletarDatosGoogle.jsx
@@ -129,7 +129,7 @@ export default function CompletarDatosGoogle() {
       return;
     }
     if (
-      rol === 'padre' &&
+      rol === 'tutor' &&
       (!nombreHijo || !apellidoHijo || !fechaNacHijo || !generoHijo)
     ) {
       show('Completa datos del hijo', 'error');
@@ -157,8 +157,8 @@ export default function CompletarDatosGoogle() {
         // nothing extra
       } else {
         data.curso = curso;
-        if (rol === 'padre') {
-          data.hijos = [
+        if (rol === 'tutor') {
+          data.alumnos = [
             {
               id: Date.now().toString(),
               nombre: nombreHijo,
@@ -184,7 +184,7 @@ export default function CompletarDatosGoogle() {
       <Card>
         <Title>Completa tu perfil</Title>
         <Form onSubmit={handleSubmit}>
-          {rol === 'padre' && (
+          {rol === 'tutor' && (
             <h3 style={{ gridColumn: '1 / -1', marginBottom: '0.5rem', color: '#034640' }}>
               Datos del tutor legal
             </h3>
@@ -244,7 +244,7 @@ export default function CompletarDatosGoogle() {
               </select>
             </Field>
           )}
-          {rol === 'padre' && (
+          {rol === 'tutor' && (
             <>
               <h3 style={{ gridColumn: '1 / -1', marginTop: '1rem', marginBottom: '0.5rem', color: '#034640' }}>
                 Datos del alumno

--- a/src/screens/ReservaClase.jsx
+++ b/src/screens/ReservaClase.jsx
@@ -262,7 +262,7 @@ const ReservaClase = () => (
         </Card>
       </CardsWrapper>
 
-      <ReserveButton to="/alta-padre">Reservar clase</ReserveButton>
+      <ReserveButton to="/alta-tutor">Reservar clase</ReserveButton>
 
       <VideoSection>
         <VideoWrapper>

--- a/src/screens/SeleccionRol.jsx
+++ b/src/screens/SeleccionRol.jsx
@@ -61,7 +61,7 @@ export default function SeleccionRol() {
       <Card>
         <Title>Selecciona tu rol</Title>
         <ButtonGroup>
-          <Button onClick={() => handleSelect('padre')}>Padre</Button>
+          <Button onClick={() => handleSelect('tutor')}>Tutor</Button>
           <Button onClick={() => handleSelect('profesor')}>Profesor</Button>
         </ButtonGroup>
       </Card>

--- a/src/screens/SignUpTutor.jsx
+++ b/src/screens/SignUpTutor.jsx
@@ -1,4 +1,4 @@
-// src/screens/SignUpPadre.jsx
+// src/screens/SignUpTutor.jsx
 import React, { useState, useEffect, useRef } from 'react';
 import styled, { keyframes } from 'styled-components';
 import { useNavigate } from 'react-router-dom';
@@ -246,7 +246,7 @@ const cursosGrouped = [
   }
 ];
 
-export default function SignUpPadre() {
+export default function SignUpTutor() {
   const [email, setEmail]           = useState('');
   const [emailError, setEmailError] = useState('');
   const [emailVerified, setEmailVerified] = useState(false);
@@ -373,10 +373,10 @@ export default function SignUpPadre() {
         apellido,
         telefono,
         ciudad,
-        rol: 'padre',
+        rol: 'tutor',
         curso,
         createdAt: new Date(),
-        hijos: [
+        alumnos: [
           {
             id: Date.now().toString(),
             nombre: nombreHijo,

--- a/src/screens/admin/acciones/Usuarios.jsx
+++ b/src/screens/admin/acciones/Usuarios.jsx
@@ -124,8 +124,7 @@ export default function Usuarios() {
 
   async function fetchStudents() {
     const snaps = [
-      await getDocs(query(collection(db, 'usuarios'), where('rol', '==', 'alumno'))),
-      await getDocs(query(collection(db, 'usuarios'), where('rol', '==', 'padre')))
+      await getDocs(query(collection(db, 'usuarios'), where('rol', '==', 'tutor')))
     ];
     const arr = [];
     for (const snap of snaps) {
@@ -168,8 +167,8 @@ export default function Usuarios() {
   const list = view === 'profesores' ? sortUsers(teachers) : sortUsers(students);
 
   const totalStudents = students.reduce((acc, s) => {
-    if (s.rol === 'padre') {
-      return acc + (s.hijos ? s.hijos.length : 0);
+    if (s.rol === 'tutor') {
+      return acc + (s.alumnos ? s.alumnos.length : 0);
     }
     return acc + 1;
   }, 0);
@@ -181,7 +180,7 @@ export default function Usuarios() {
         <Counter>
           Total {view === 'profesores' ? teachers.length : totalStudents}
         </Counter>
-        <ToggleSwitch leftLabel="Profesores" rightLabel="Alumnos / Padres" value={view === "profesores" ? "left" : "right"} onChange={(val) => setView(val === "left" ? "profesores" : "alumnos")}/>
+        <ToggleSwitch leftLabel="Profesores" rightLabel="Alumnos / Tutores" value={view === "profesores" ? "left" : "right"} onChange={(val) => setView(val === "left" ? "profesores" : "alumnos")}/>
 
         <FilterContainer>
           <label htmlFor="sortUsuarios">Ordenar por:</label>
@@ -202,9 +201,9 @@ export default function Usuarios() {
             {list.map(u => (
               <Item key={u.id}>
                 <UserLink to={`/perfil/${u.id}`}>{u.nombre} {u.apellido}</UserLink>
-                {u.rol === 'padre' && (u.hijos || []).length > 0 && (
+                {u.rol === 'tutor' && (u.alumnos || []).length > 0 && (
                   <ChildrenList>
-                    {u.hijos.map(h => (
+                    {u.alumnos.map(h => (
                       <li key={h.id}>{h.nombre}</li>
                     ))}
                   </ChildrenList>

--- a/src/screens/alumno/PanelAlumno.jsx
+++ b/src/screens/alumno/PanelAlumno.jsx
@@ -13,7 +13,7 @@ import NuevaClase    from './acciones/NuevaClase';
 import Clases        from './acciones/Clases';
 import MisProfesores from './acciones/MisProfesores';
 import CalendarioA   from './acciones/Calendario';
-import MisHijos      from './acciones/MisHijos';
+import MisAlumnos    from './acciones/MisAlumnos';
 
 const Container = styled.div`
   display: flex;
@@ -104,7 +104,7 @@ export default function PanelAlumno() {
       firstRender.current = false;
       return;
     }
-    if (userData?.rol === 'padre') {
+    if (userData?.rol === 'tutor') {
       if (selectedChild) {
         show(
           <span>
@@ -114,7 +114,7 @@ export default function PanelAlumno() {
           2000
         );
       } else {
-        show('No hay hijo seleccionado', 'error', 2000);
+        show('No hay alumno seleccionado', 'error', 2000);
       }
     }
   }, [selectedChild, userData, show]);
@@ -131,16 +131,16 @@ export default function PanelAlumno() {
       case 'clases':         return requireChild(<Clases />);
       case 'mis-profesores': return requireChild(<MisProfesores />);
       case 'calendario':     return requireChild(<CalendarioA />);
-      case 'mis-hijos':      return <MisHijos />;
+      case 'mis-alumnos':      return <MisAlumnos />;
       default:               return <NuevaClase />;
     }
   };
 
   const requireChild = component => {
-    if (userData?.rol === 'padre' && !selectedChild) {
+    if (userData?.rol === 'tutor' && !selectedChild) {
       return (
         <CenterMessage>
-          Selecciona un hijo para continuar
+          Selecciona un alumno para continuar
         </CenterMessage>
       );
     }
@@ -148,8 +148,8 @@ export default function PanelAlumno() {
   };
 
   const handleMenuClick = name => {
-    if (userData?.rol === 'padre' && !selectedChild && name !== 'mis-hijos') {
-      show('Selecciona un hijo primero', 'error');
+    if (userData?.rol === 'tutor' && !selectedChild && name !== 'mis-alumnos') {
+      show('Selecciona un alumno primero', 'error');
       return;
     }
     setView(name);
@@ -193,13 +193,13 @@ export default function PanelAlumno() {
               Calendario
             </Button>
           </MenuItem>
-          {userData?.rol === 'padre' && (
+          {userData?.rol === 'tutor' && (
             <MenuItem>
               <Button
-                active={view === 'mis-hijos'}
-                onClick={() => handleMenuClick('mis-hijos')}
+                active={view === 'mis-alumnos'}
+                onClick={() => handleMenuClick('mis-alumnos')}
               >
-                Mis hijos
+                Mis alumnos
               </Button>
             </MenuItem>
           )}
@@ -210,7 +210,7 @@ export default function PanelAlumno() {
         {renderView()}
       </Content>
     </Container>
-    {userData?.rol === 'padre' && (
+    {userData?.rol === 'tutor' && (
       <>
         <ChildSelectorBubble onAddChild={() => setShowAddChild(true)} />
         <AddChildModal open={showAddChild} onClose={() => setShowAddChild(false)} />

--- a/src/screens/alumno/acciones/MisAlumnos.jsx
+++ b/src/screens/alumno/acciones/MisAlumnos.jsx
@@ -98,7 +98,7 @@ const ModalButton = styled.button`
       : `background: #f0f0f0; color: #333;`}
 `;
 
-export default function MisHijos() {
+export default function MisAlumnos() {
   const { childList, setChildList, setSelectedChild } = useChild();
   const { userData } = useAuth();
   const [nombre, setNombre] = useState('');
@@ -116,7 +116,7 @@ export default function MisHijos() {
       photoURL: userData?.photoURL || auth.currentUser.photoURL || ''
     };
     const nuevos = [...childList, nuevo];
-    await updateDoc(doc(db, 'usuarios', auth.currentUser.uid), { hijos: nuevos });
+    await updateDoc(doc(db, 'usuarios', auth.currentUser.uid), { alumnos: nuevos });
     setChildList(nuevos.filter(c => !c.disabled));
     setSelectedChild(nuevo);
     setNombre('');
@@ -128,7 +128,7 @@ export default function MisHijos() {
     const nuevos = childList.map(c =>
       c.id === child.id ? { ...c, disabled: true } : c
     );
-    await updateDoc(doc(db, 'usuarios', auth.currentUser.uid), { hijos: nuevos });
+    await updateDoc(doc(db, 'usuarios', auth.currentUser.uid), { alumnos: nuevos });
     const activos = nuevos.filter(c => !c.disabled);
     setChildList(activos);
     setSelectedChild(activos[0] || null);
@@ -137,7 +137,7 @@ export default function MisHijos() {
   return (
     <Page>
       <Container>
-        <Title>Mis hijos</Title>
+        <Title>Mis alumnos</Title>
         <List>
           {childList.map(c => (
             <Item key={c.id}>
@@ -152,7 +152,7 @@ export default function MisHijos() {
                 disabled={childList.length <= 1}
                 title={
                   childList.length <= 1
-                    ? 'Deberás añadir un hijo antes de eliminar el último que tienes'
+                    ? 'Deberás añadir un alumno antes de eliminar el último que tienes'
                     : ''
                 }
                 onClick={() => setChildToDelete(c)}
@@ -164,7 +164,7 @@ export default function MisHijos() {
         </List>
 
         <Form>
-          <h3>Añadir nuevo hijo</h3>
+          <h3>Añadir nuevo alumno</h3>
           <div>
             <TextInput
               type="text"

--- a/src/screens/alumno/acciones/NuevaClase.jsx
+++ b/src/screens/alumno/acciones/NuevaClase.jsx
@@ -370,7 +370,7 @@ export default function NuevaClase() {
       const snap = await getDoc(doc(db, 'usuarios', u.uid));
       if (snap.exists()) {
         const d = snap.data();
-        if (d.rol === 'padre' && selectedChild) {
+        if (d.rol === 'tutor' && selectedChild) {
           setAlumnoNombre(selectedChild.nombre);
           setAlumnoApellidos('');
           setCurso(selectedChild.curso || '');
@@ -531,8 +531,8 @@ export default function NuevaClase() {
         alumnoId: auth.currentUser.uid,
         alumnoNombre,
         alumnoApellidos,
-        hijoId: userData?.rol === 'padre' ? selectedChild?.id : null,
-        padreNombre: userData?.rol === 'padre' ? userData.nombre : null,
+        hijoId: userData?.rol === 'tutor' ? selectedChild?.id : null,
+        padreNombre: userData?.rol === 'tutor' ? userData.nombre : null,
         asignatura: asignaturas[0] || '',
         asignaturas,
         curso,
@@ -563,7 +563,7 @@ export default function NuevaClase() {
 
   const handleSuccessClose = () => {
     setSuccessModal(false);
-    navigate('/alumno?tab=clases&view=solicitudes');
+    navigate('/tutor?tab=clases&view=solicitudes');
   };
 
   return (
@@ -571,7 +571,7 @@ export default function NuevaClase() {
       <Card>
         <Title>
           Solicitar nueva clase
-          {userData?.rol === 'padre' && alumnoNombre && ` para ${alumnoNombre}`}
+          {userData?.rol === 'tutor' && alumnoNombre && ` para ${alumnoNombre}`}
         </Title>
         <Subtitle>Encuentra al profesor ideal para ti</Subtitle>
 

--- a/src/screens/shared/Perfil.jsx
+++ b/src/screens/shared/Perfil.jsx
@@ -336,9 +336,9 @@ export default function Perfil() {
       curso: childCourse,
       photoURL,
     };
-    const nuevos = [...(profile.hijos || []), nuevo];
-    await updateDoc(doc(db, 'usuarios', userId), { hijos: nuevos });
-    setProfile(p => ({ ...p, hijos: nuevos }));
+    const nuevos = [...(profile.alumnos || []), nuevo];
+    await updateDoc(doc(db, 'usuarios', userId), { alumnos: nuevos });
+    setProfile(p => ({ ...p, alumnos: nuevos }));
     if (auth.currentUser && auth.currentUser.uid === userId) {
       setChildList(nuevos.filter(c => !c.disabled));
       setSelectedChild(nuevo);
@@ -667,14 +667,14 @@ export default function Perfil() {
           </div>
         </ProfileHeader>
 
-        {profile.rol === 'padre' && (
+        {profile.rol === 'tutor' && (
           <Section>
-            <h2 style={{ textAlign: 'center', color: '#024837' }}>Hijos</h2>
-            {(profile.hijos || []).length === 0 ? (
-              <p style={{ textAlign: 'center', color: '#666' }}>Aún no hay hijos registrados.</p>
+            <h2 style={{ textAlign: 'center', color: '#024837' }}>Alumnos</h2>
+            {(profile.alumnos || []).length === 0 ? (
+              <p style={{ textAlign: 'center', color: '#666' }}>Aún no hay alumnos registrados.</p>
             ) : (
               <ChildList>
-                {profile.hijos.map(h => (
+                {profile.alumnos.map(h => (
                   <ChildItem key={h.id}>
                     {profile.photoURL && <ChildImg src={profile.photoURL} alt="foto" />}
                     <div>
@@ -689,7 +689,7 @@ export default function Perfil() {
             {isOwnProfile && (
               <>
                 {!showAddChild && (
-                  <EditButton onClick={() => setShowAddChild(true)}>Añadir hijo</EditButton>
+                  <EditButton onClick={() => setShowAddChild(true)}>Añadir alumno</EditButton>
                 )}
                 {showAddChild && (
                   <AddChildForm>


### PR DESCRIPTION
## Summary
- rename `padre` role to `tutor` across the frontend
- update routes and navigation for the new role name
- rename database field `hijos` to `alumnos`
- adjust admin queries and panels to match the new terminology
- update Node server to accept the new role name

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ba5867758832bbaaed9bb42d5afa7