### PR TITLE
Store registrations in Postgres and load options from DB

### DIFF
--- a/node-server/index.js
+++ b/node-server/index.js
@@ -51,6 +51,46 @@ async function appendRow(sheetName, values) {
   });
 }
 
+// --- Lookup endpoints ----------------------------------------------------
+// These endpoints expose simple catalog data so the frontend can populate
+// dropdowns from the PostgreSQL database rather than from hardcoded lists.
+
+app.get('/ciudades', async (_req, res) => {
+  try {
+    const result = await db.query(
+      'SELECT id_ciudad, nombre FROM student_project.ciudad ORDER BY nombre'
+    );
+    res.json(result.rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Error fetching ciudades' });
+  }
+});
+
+app.get('/cursos', async (_req, res) => {
+  try {
+    const result = await db.query(
+      'SELECT id_curso, nombre FROM student_project.curso ORDER BY id_curso'
+    );
+    res.json(result.rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Error fetching cursos' });
+  }
+});
+
+app.get('/asignaturas', async (_req, res) => {
+  try {
+    const result = await db.query(
+      'SELECT id_asignatura, nombre_asignatura FROM student_project.asignatura ORDER BY nombre_asignatura'
+    );
+    res.json(result.rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Error fetching asignaturas' });
+  }
+});
+
 app.post('/tutor', async (req, res) => {
   const {
     nombre,

--- a/src/screens/SignUpProfesor.jsx
+++ b/src/screens/SignUpProfesor.jsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { useNotification } from "../NotificationContext";
 import { isValidEmail } from '../utils/validateEmail';
 import { sendWelcomeEmail, sendVerificationCode } from '../utils/email';
+import { fetchCities, registerProfesor } from '../utils/api';
 import PhoneInput from 'react-phone-input-2';
 import 'react-phone-input-2/lib/style.css';
 
@@ -244,16 +245,22 @@ export default function SignUpProfesor() {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [modalOpen, setModalOpen]     = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [nif, setNif] = useState('');
+  const [direccionFacturacion, setDireccionFacturacion] = useState('');
+  const [iban, setIban] = useState('');
+  const [carrera, setCarrera] = useState('');
+  const [cursoEstudios, setCursoEstudios] = useState('');
+  const [experiencia, setExperiencia] = useState('');
   const navigate = useNavigate();
   const { show } = useNotification();
   const ref = useRef();
 
-  // Carga ciudades
+  // Carga ciudades desde la API
   useEffect(() => {
     (async () => {
       try {
-        const snap = await getDocs(collection(db, 'ciudades'));
-        setCities(snap.docs.map(d => d.data().ciudad));
+        const list = await fetchCities();
+        setCities(list.map(c => c.nombre));
       } catch (err) {
         console.error(err);
       }
@@ -299,7 +306,23 @@ export default function SignUpProfesor() {
 
   const handleSubmit = async () => {
     if (submitting) return;
-    if (!email || !password || !confirmPassword || !nombre || !apellido || !telefono || !confirmTelefono || !ciudad || !emailVerified) {
+    if (
+      !email ||
+      !password ||
+      !confirmPassword ||
+      !nombre ||
+      !apellido ||
+      !telefono ||
+      !confirmTelefono ||
+      !ciudad ||
+      !nif ||
+      !direccionFacturacion ||
+      !iban ||
+      !carrera ||
+      !cursoEstudios ||
+      !experiencia ||
+      !emailVerified
+    ) {
       show('Completa todos los campos', 'error');
       return;
     }
@@ -333,7 +356,27 @@ export default function SignUpProfesor() {
         telefono,
         ciudad,
         rol: 'profesor',
-        createdAt: new Date()
+        createdAt: new Date(),
+        NIF: nif,
+        direccion: direccionFacturacion,
+        IBAN: iban,
+        carrera,
+        curso: cursoEstudios,
+        experiencia,
+      });
+      const genero = salutation === 'Sr.' ? 'Masculino' : 'Femenino';
+      await registerProfesor({
+        nombre,
+        apellidos: apellido,
+        genero,
+        telefono,
+        correo_electronico: email,
+        NIF: nif,
+        direccion_facturacion: direccionFacturacion,
+        IBAN: iban,
+        carrera,
+        curso: cursoEstudios,
+        experiencia,
       });
       await sendWelcomeEmail({ email, name: nombre });
       if (auth.currentUser) {
@@ -452,6 +495,78 @@ export default function SignUpProfesor() {
                 placeholder=" "
               />
               <label className="fl-label">Apellidos</label>
+            </div>
+          </Field>
+          <Field>
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="text"
+                value={nif}
+                onChange={e => setNif(e.target.value)}
+                placeholder=" "
+              />
+              <label className="fl-label">NIF</label>
+            </div>
+          </Field>
+          <Field>
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="text"
+                value={direccionFacturacion}
+                onChange={e => setDireccionFacturacion(e.target.value)}
+                placeholder=" "
+              />
+              <label className="fl-label">Dirección facturación</label>
+            </div>
+          </Field>
+          <Field>
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="text"
+                value={iban}
+                onChange={e => setIban(e.target.value)}
+                placeholder=" "
+              />
+              <label className="fl-label">IBAN</label>
+            </div>
+          </Field>
+          <Field>
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="text"
+                value={carrera}
+                onChange={e => setCarrera(e.target.value)}
+                placeholder=" "
+              />
+              <label className="fl-label">Carrera</label>
+            </div>
+          </Field>
+          <Field>
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="text"
+                value={cursoEstudios}
+                onChange={e => setCursoEstudios(e.target.value)}
+                placeholder=" "
+              />
+              <label className="fl-label">Curso</label>
+            </div>
+          </Field>
+          <Field style={{ gridColumn: '1 / -1' }}>
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="text"
+                value={experiencia}
+                onChange={e => setExperiencia(e.target.value)}
+                placeholder=" "
+              />
+              <label className="fl-label">Experiencia</label>
             </div>
           </Field>
           <Field style={{ gridColumn: '1 / -1' }} ref={ref}>

--- a/src/screens/SignUpTutor.jsx
+++ b/src/screens/SignUpTutor.jsx
@@ -5,6 +5,12 @@ import { useNavigate } from 'react-router-dom';
 import { useNotification } from "../NotificationContext";
 import { isValidEmail } from '../utils/validateEmail';
 import { sendWelcomeEmail, sendVerificationCode } from '../utils/email';
+import {
+  fetchCities,
+  fetchCursos,
+  registerTutor,
+  registerAlumno,
+} from '../utils/api';
 import PhoneInput from 'react-phone-input-2';
 import 'react-phone-input-2/lib/style.css';
 
@@ -226,26 +232,6 @@ const ModalButton = styled.button`
   }
 `;
 
-// Cursos agrupados igual que en NuevaClase
-const cursosGrouped = [
-  {
-    group: 'Primaria',
-    options: [
-      '1º Primaria',
-      '2º Primaria',
-      '3º Primaria',
-      '4º Primaria',
-      '5º Primaria',
-      '6º Primaria'
-    ]
-  },
-  { group: 'ESO', options: ['1º ESO', '2º ESO', '3º ESO', '4º ESO'] },
-  {
-    group: 'Bachillerato',
-    options: ['1º Bachillerato', '2º Bachillerato']
-  }
-];
-
 export default function SignUpTutor() {
   const [email, setEmail]           = useState('');
   const [emailError, setEmailError] = useState('');
@@ -264,8 +250,14 @@ export default function SignUpTutor() {
   const [ciudad, setCiudad]         = useState('');
   const [cities, setCities]         = useState([]);
   const [curso, setCurso]           = useState('');
+  const [courses, setCourses]       = useState([]);
   const [cityOpen, setCityOpen]     = useState(false);
   const [courseOpen, setCourseOpen] = useState(false);
+  const [nifTutor, setNifTutor] = useState('');
+  const [direccionTutor, setDireccionTutor] = useState('');
+  const [nifAlumno, setNifAlumno] = useState('');
+  const [telefonoHijo, setTelefonoHijo] = useState('');
+  const [direccionAlumno, setDireccionAlumno] = useState('');
   const [nombreHijo, setNombreHijo] = useState('');
   const [apellidoHijo, setApellidoHijo] = useState('');
   const [fechaNacHijo, setFechaNacHijo] = useState('');
@@ -287,8 +279,10 @@ export default function SignUpTutor() {
   useEffect(() => {
     (async () => {
       try {
-        const snapCities = await getDocs(collection(db, 'ciudades'));
-        setCities(snapCities.docs.map(d => d.data().ciudad));
+        const cityList = await fetchCities();
+        setCities(cityList.map(c => c.nombre));
+        const courseList = await fetchCursos();
+        setCourses(courseList.map(c => c.nombre));
       } catch (err) {
         console.error(err);
       }
@@ -337,6 +331,11 @@ export default function SignUpTutor() {
       !confirmTelefono ||
       !ciudad ||
       !curso ||
+      !nifTutor ||
+      !direccionTutor ||
+      !nifAlumno ||
+      !telefonoHijo ||
+      !direccionAlumno ||
       !emailVerified
     ) {
       show('Completa todos los campos', 'error');
@@ -375,6 +374,8 @@ export default function SignUpTutor() {
         ciudad,
         rol: 'tutor',
         curso,
+        NIF: nifTutor,
+        direccion: direccionTutor,
         createdAt: new Date(),
         alumnos: [
           {
@@ -384,11 +385,32 @@ export default function SignUpTutor() {
             genero: generoHijo,
             fechaNacimiento: fechaNacHijo,
             curso,
+            telefono: telefonoHijo,
+            NIF: nifAlumno,
+            direccion: direccionAlumno,
             photoURL: user.photoURL || ''
           },
         ]
       };
       await setDoc(doc(db, 'usuarios', user.uid), data);
+      const generoTutor = salutation === 'Sr.' ? 'Masculino' : 'Femenino';
+      const tutorResp = await registerTutor({
+        nombre,
+        apellidos: apellido,
+        genero: generoTutor,
+        telefono,
+        correo_electronico: email,
+        NIF: nifTutor,
+        direccion_facturacion: direccionTutor,
+      });
+      await registerAlumno(tutorResp.id, {
+        nombre: nombreHijo,
+        apellidos: apellidoHijo,
+        direccion: direccionAlumno,
+        NIF: nifAlumno,
+        telefono: telefonoHijo,
+        genero: generoHijo,
+      });
       await sendWelcomeEmail({ email, name: nombre });
       if (auth.currentUser) {
         await sendEmailVerification(auth.currentUser);
@@ -492,6 +514,30 @@ export default function SignUpTutor() {
             </div>
           </Field>
           <Field>
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="text"
+                value={nifTutor}
+                onChange={e => setNifTutor(e.target.value)}
+                placeholder=" "
+              />
+              <label className="fl-label">NIF</label>
+            </div>
+          </Field>
+          <Field>
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="text"
+                value={direccionTutor}
+                onChange={e => setDireccionTutor(e.target.value)}
+                placeholder=" "
+              />
+              <label className="fl-label">Dirección facturación</label>
+            </div>
+          </Field>
+          <Field>
             <label>Teléfono</label>
             <PhoneInput
               country={'es'}
@@ -539,21 +585,16 @@ export default function SignUpTutor() {
               </DropdownHeader>
               {courseOpen && (
                 <DropdownList>
-                  {cursosGrouped.map(({ group, options }) => (
-                    <React.Fragment key={group}>
-                      <DropdownGroupLabel>{group}</DropdownGroupLabel>
-                      {options.map((c, i) => (
-                        <DropdownItem
-                          key={i}
-                          onClick={() => {
-                            setCurso(c);
-                            setCourseOpen(false);
-                          }}
-                        >
-                          {c}
-                        </DropdownItem>
-                      ))}
-                    </React.Fragment>
+                  {courses.map((c, i) => (
+                    <DropdownItem
+                      key={i}
+                      onClick={() => {
+                        setCurso(c);
+                        setCourseOpen(false);
+                      }}
+                    >
+                      {c}
+                    </DropdownItem>
                   ))}
                 </DropdownList>
               )}
@@ -582,6 +623,39 @@ export default function SignUpTutor() {
                 placeholder=" "
               />
               <label className="fl-label">Apellidos del Alumno</label>
+            </div>
+          </Field>
+          <Field>
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="text"
+                value={nifAlumno}
+                onChange={e=>setNifAlumno(e.target.value)}
+                placeholder=" "
+              />
+              <label className="fl-label">NIF del Alumno</label>
+            </div>
+          </Field>
+          <Field>
+            <label>Teléfono del Alumno</label>
+            <PhoneInput
+              country={'es'}
+              value={telefonoHijo}
+              onChange={value => setTelefonoHijo(value)}
+              inputStyle={{ width: '100%' }}
+            />
+          </Field>
+          <Field>
+            <div className="fl-field">
+              <input
+                className="form-control fl-input"
+                type="text"
+                value={direccionAlumno}
+                onChange={e=>setDireccionAlumno(e.target.value)}
+                placeholder=" "
+              />
+              <label className="fl-label">Dirección del Alumno</label>
             </div>
           </Field>
           <Field>

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,51 @@
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:3001';
+
+async function handleResponse(res) {
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || 'Error de servidor');
+  }
+  return res.json();
+}
+
+export async function fetchCities() {
+  const res = await fetch(`${API_URL}/ciudades`);
+  return handleResponse(res);
+}
+
+export async function fetchCursos() {
+  const res = await fetch(`${API_URL}/cursos`);
+  return handleResponse(res);
+}
+
+export async function fetchAsignaturas() {
+  const res = await fetch(`${API_URL}/asignaturas`);
+  return handleResponse(res);
+}
+
+export async function registerTutor(data) {
+  const res = await fetch(`${API_URL}/tutor`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  return handleResponse(res);
+}
+
+export async function registerAlumno(tutorId, data) {
+  const res = await fetch(`${API_URL}/tutor/${tutorId}/alumno`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  return handleResponse(res);
+}
+
+export async function registerProfesor(data) {
+  const res = await fetch(`${API_URL}/profesor`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  return handleResponse(res);
+}


### PR DESCRIPTION
## Summary
- expose lookup endpoints for cities, courses and subjects in Node API
- add frontend API utilities and use them in tutor/professor sign-up
- collect required fields and persist tutors, students and professors to PostgreSQL

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689bbec24758832ba43996d3024e7003