### PR TITLE
Fix verification code button interaction

### DIFF
--- a/src/screens/SignUpProfesor.jsx
+++ b/src/screens/SignUpProfesor.jsx
@@ -284,7 +284,8 @@ export default function SignUpProfesor() {
     return () => document.removeEventListener('mousedown', handler);
   }, []);
 
-  const handleSendCode = async () => {
+  const handleSendCode = async (e) => {
+    e.preventDefault();
     if (!isValidEmail(email)) {
       setEmailError('Correo electrónico no válido.');
       return;
@@ -295,7 +296,8 @@ export default function SignUpProfesor() {
     setSendCooldown(30);
   };
 
-  const handleCheckCode = () => {
+  const handleCheckCode = (e) => {
+    e.preventDefault();
     if (codeInput === verifCode) {
       setEmailVerified(true);
       show('Correo verificado', 'success');
@@ -587,7 +589,7 @@ export default function SignUpProfesor() {
             </DropdownContainer>
           </Field>
         </FormGrid>
-        <Button onClick={handleSubmit} disabled={submitting}>Crear cuenta de profesor</Button>
+        <Button type="button" onClick={handleSubmit} disabled={submitting}>Crear cuenta de profesor</Button>
       </Card>
 
       {modalOpen && (

--- a/src/screens/SignUpTutor.jsx
+++ b/src/screens/SignUpTutor.jsx
@@ -299,7 +299,8 @@ export default function SignUpTutor() {
     return () => document.removeEventListener('mousedown', handleClick);
   }, []);
 
-  const handleSendCode = async () => {
+  const handleSendCode = async (e) => {
+    e.preventDefault();
     if (!isValidEmail(email)) {
       setEmailError('Correo electrónico no válido.');
       return;
@@ -310,7 +311,8 @@ export default function SignUpTutor() {
     setSendCooldown(30);
   };
 
-  const handleCheckCode = () => {
+  const handleCheckCode = (e) => {
+    e.preventDefault();
     if (codeInput === verifCode) {
       setEmailVerified(true);
       show('Correo verificado', 'success');
@@ -682,7 +684,7 @@ export default function SignUpTutor() {
           </p>
         </FormGrid>
 
-        <Button onClick={handleSubmit} disabled={submitting}>Crear cuenta</Button>
+        <Button type="button" onClick={handleSubmit} disabled={submitting}>Crear cuenta</Button>
       </Card>
 
       {modalOpen && (


### PR DESCRIPTION
## Summary
- prevent default form submission when sending or checking verification codes
- set registration submit buttons to type="button" to avoid unintended submission

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bcb85e8f0832b9b5cfd0541567795