### PR TITLE
Improve signup flow and store hashed passwords

### DIFF
--- a/bbdd/sp_bbdd.sql
+++ b/bbdd/sp_bbdd.sql
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS student_project.tutor
     correo_electronico VARCHAR(100),
     "NIF" VARCHAR(100) NOT NULL,
     direccion_facturacion VARCHAR(100) NOT NULL,
+    password VARCHAR(255) NOT NULL,
     PRIMARY KEY (id_tutor)
 );
 
@@ -155,7 +156,8 @@ CREATE TABLE IF NOT EXISTS student_project.profesor
     "IBAN" VARCHAR(100) NOT NULL,
     carrera VARCHAR(100) NOT NULL,
     curso VARCHAR(100) NOT NULL,
-    experiencia TEXT NOT NULL
+    experiencia TEXT NOT NULL,
+    password VARCHAR(255) NOT NULL
 );
 
 COMMENT ON TABLE student_project.profesor

--- a/node-server/index.js
+++ b/node-server/index.js
@@ -7,6 +7,7 @@ const admin = require('firebase-admin');
 const jwt = require('jsonwebtoken');
 const { google } = require('googleapis');
 const db = require('./db');
+const bcrypt = require('bcryptjs');
 
 const app = express();
 app.use(cors());
@@ -100,11 +101,13 @@ app.post('/tutor', async (req, res) => {
     correo_electronico,
     NIF,
     direccion_facturacion,
+    password,
   } = req.body;
   try {
+    const hashed = await bcrypt.hash(password, 10);
     const result = await db.query(
-      'INSERT INTO student_project.tutor (nombre, apellidos, genero, telefono, correo_electronico, "NIF", direccion_facturacion) VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING id_tutor',
-      [nombre, apellidos, genero, telefono, correo_electronico, NIF, direccion_facturacion]
+      'INSERT INTO student_project.tutor (nombre, apellidos, genero, telefono, correo_electronico, "NIF", direccion_facturacion, password) VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING id_tutor',
+      [nombre, apellidos, genero, telefono, correo_electronico, NIF, direccion_facturacion, hashed]
     );
     res.json({ id: result.rows[0].id_tutor });
   } catch (err) {
@@ -141,11 +144,13 @@ app.post('/profesor', async (req, res) => {
     carrera,
     curso,
     experiencia,
+    password,
   } = req.body;
   try {
+    const hashed = await bcrypt.hash(password, 10);
     const result = await db.query(
-      'INSERT INTO student_project.profesor (nombre, apellidos, genero, telefono, correo_electronico, "NIF", direccion_facturacion, "IBAN", carrera, curso, experiencia) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11) RETURNING id_profesor',
-      [nombre, apellidos, genero, telefono, correo_electronico, NIF, direccion_facturacion, IBAN, carrera, curso, experiencia]
+      'INSERT INTO student_project.profesor (nombre, apellidos, genero, telefono, correo_electronico, "NIF", direccion_facturacion, "IBAN", carrera, curso, experiencia, password) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12) RETURNING id_profesor',
+      [nombre, apellidos, genero, telefono, correo_electronico, NIF, direccion_facturacion, IBAN, carrera, curso, experiencia, hashed]
     );
     res.json({ id: result.rows[0].id_profesor });
   } catch (err) {

--- a/node-server/package-lock.json
+++ b/node-server/package-lock.json
@@ -8,6 +8,7 @@
       "name": "studentproject-mailer",
       "version": "1.0.0",
       "dependencies": {
+        "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
@@ -648,6 +649,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
     },
     "node_modules/bignumber.js": {

--- a/node-server/package.json
+++ b/node-server/package.json
@@ -14,6 +14,7 @@
     "firebase-admin": "^13.4.0",
     "googleapis": "^118.0.0",
     "jsonwebtoken": "^9.0.2",
+    "bcryptjs": "^2.4.3",
     "nodemailer": "^6.9.13",
     "pg": "^8.16.3"
   },

--- a/src/theme.js
+++ b/src/theme.js
@@ -37,4 +37,8 @@ export const GlobalStyle = createGlobalStyle`
     color: inherit;
     text-decoration: none;
   }
+
+  button, input, select, textarea {
+    font-family: inherit;
+  }
 `;


### PR DESCRIPTION
## Summary
- unify form typography and add consistent styling for verification widgets
- hash and store user passwords in PostgreSQL
- move password entry to initial signup step and color-code verification

## Testing
- `npm --prefix node-server install`
- `npm test -- --watchAll=false`
- `npm --prefix node-server test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689cc54de7b0832bb81d9cbd95faa747