### PR TITLE
Fix radio button color on tutor new class screen

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,6 +9,12 @@
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
+/* Color corporativo para radios y checkboxes */
+input[type="radio"].form-control,
+input[type="checkbox"].form-control {
+  accent-color: #00A859;
+}
+
 /* ESTADO FOCUS: borde y sombra con verde corporativo */
 .form-control:focus {
   outline: none;


### PR DESCRIPTION
## Summary
- Style radio and checkbox controls with corporate green accent color

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689d24d74810832b875a86158ead8d0d