### PR TITLE
Enforce unique tutor email and phone number

### DIFF
--- a/bbdd/sp_bbdd.sql
+++ b/bbdd/sp_bbdd.sql
@@ -34,16 +34,14 @@ COMMENT ON TABLE student_project.asignatura
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS student_project.tutor
 (
-    id_tutor serial NOT NULL,
+    correo_electronico VARCHAR(100) PRIMARY KEY,
     nombre VARCHAR(100),
     apellidos VARCHAR(100),
     genero VARCHAR(100),
-    telefono VARCHAR(25),
-    correo_electronico VARCHAR(100),
+    telefono VARCHAR(25) UNIQUE,
     "NIF" VARCHAR(100) NOT NULL,
     direccion_facturacion VARCHAR(100) NOT NULL,
-    password VARCHAR(255) NOT NULL,
-    PRIMARY KEY (id_tutor)
+    password VARCHAR(255) NOT NULL
 );
 
 
@@ -122,15 +120,15 @@ CREATE TABLE IF NOT EXISTS student_project.alumno
     apellidos VARCHAR(100),
     direccion VARCHAR(100),
     NIF VARCHAR(100) NOT NULL,
-    telefono VARCHAR(25),
-    genero VARCHAR(100),	
-	  
-	id_tutor INT NOT NULL REFERENCES student_project.tutor(id_tutor)
+    telefono VARCHAR(25) UNIQUE,
+    genero VARCHAR(100),
+
+        correo_tutor VARCHAR(100) NOT NULL REFERENCES student_project.tutor(correo_electronico)
     ON DELETE RESTRICT
-    ON UPDATE CASCADE,	
-	id_curso INT NOT NULL REFERENCES student_project.curso(id_curso)
+    ON UPDATE CASCADE,
+        id_curso INT NOT NULL REFERENCES student_project.curso(id_curso)
     ON DELETE RESTRICT
-    ON UPDATE CASCADE,	
+    ON UPDATE CASCADE,
 	id_ubicacion INT NOT NULL REFERENCES student_project.ubicacion(id_ubicacion)
     ON DELETE RESTRICT
     ON UPDATE CASCADE	
@@ -149,7 +147,7 @@ CREATE TABLE IF NOT EXISTS student_project.profesor
     nombre VARCHAR(100),
     apellidos VARCHAR(100),
     genero VARCHAR(100),
-    telefono VARCHAR(25),
+    telefono VARCHAR(25) UNIQUE,
     correo_electronico VARCHAR(100),
     "NIF" VARCHAR(100) NOT NULL,
     direccion_facturacion VARCHAR(100) NOT NULL,

--- a/src/screens/SignUpTutor.jsx
+++ b/src/screens/SignUpTutor.jsx
@@ -9,7 +9,6 @@ import {
   fetchCities,
   fetchCursos,
   registerTutor,
-  registerAlumno,
 } from '../utils/api';
 import PhoneInput from 'react-phone-input-2';
 import 'react-phone-input-2/lib/style.css';
@@ -465,28 +464,29 @@ export default function SignUpTutor() {
       };
       await setDoc(doc(db, 'usuarios', user.uid), data);
       const generoTutor = salutation === 'Sr.' ? 'Masculino' : 'Femenino';
-      const tutorResp = await registerTutor({
-        nombre,
-        apellidos: apellido,
-        genero: generoTutor,
-        telefono,
-        correo_electronico: email,
-        NIF: nifTutor,
-        direccion_facturacion: direccionTutor,
-        distrito_facturacion: distritoTutor,
-        password,
-      });
-      await registerAlumno(tutorResp.id, {
-        nombre: nombreHijo,
-        apellidos: apellidoHijo,
-        direccion: direccionAlumno,
-        distrito: distritoAlumno,
-        ciudad,
-        NIF: nifAlumno,
-        telefono: telefonoHijo,
-        telefonoConfirm: confirmTelefonoHijo,
-        genero: generoHijo,
-        id_curso: idCurso,
+      await registerTutor({
+        tutor: {
+          nombre,
+          apellidos: apellido,
+          genero: generoTutor,
+          telefono,
+          correo_electronico: email,
+          NIF: nifTutor,
+          direccion_facturacion: direccionTutor,
+          password,
+        },
+        alumno: {
+          nombre: nombreHijo,
+          apellidos: apellidoHijo,
+          direccion: direccionAlumno,
+          distrito: distritoAlumno,
+          ciudad,
+          NIF: nifAlumno,
+          telefono: telefonoHijo,
+          telefonoConfirm: confirmTelefonoHijo,
+          genero: generoHijo,
+          id_curso: idCurso,
+        }
       });
       await sendWelcomeEmail({ email, name: nombre });
       if (auth.currentUser) {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -39,15 +39,6 @@ export async function registerTutor(data) {
   return handleResponse(res);
 }
 
-export async function registerAlumno(tutorId, data) {
-  const res = await fetch(`${API_URL}/tutor/${tutorId}/alumno`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-  });
-  return handleResponse(res);
-}
-
 export async function registerProfesor(data) {
   const res = await fetch(`${API_URL}/profesor`, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- Make tutor email the primary key and enforce unique phones across users
- Register tutor and child atomically via single endpoint
- Update frontend to use new unified registration API

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689dc788ca58832b913c9bab6875c1fe