### PR TITLE
Añadir campos de ubicación en registros de tutor y profesor

### DIFF
--- a/src/screens/SignUpProfesor.jsx
+++ b/src/screens/SignUpProfesor.jsx
@@ -292,6 +292,8 @@ export default function SignUpProfesor() {
   const [nif, setNif] = useState('');
   const [direccionFacturacion, setDireccionFacturacion] = useState('');
   const [distrito, setDistrito] = useState('');
+  const [barrio, setBarrio] = useState('');
+  const [codigoPostal, setCodigoPostal] = useState('');
   const [iban, setIban] = useState('');
   const [carrera, setCarrera] = useState('');
   const [cursoEstudios, setCursoEstudios] = useState('');
@@ -371,6 +373,8 @@ export default function SignUpProfesor() {
     if (!nif) missing.push('NIF');
     if (!direccionFacturacion) missing.push('Dirección facturación');
     if (!distrito) missing.push('Distrito');
+    if (!barrio) missing.push('Barrio');
+    if (!codigoPostal) missing.push('Código Postal');
     if (!iban) missing.push('IBAN');
     if (!carrera) missing.push('Carrera');
     if (!cursoEstudios) missing.push('Curso');
@@ -416,6 +420,8 @@ export default function SignUpProfesor() {
         NIF: nif,
         direccion: direccionFacturacion,
         distrito,
+        barrio,
+        codigo_postal: codigoPostal,
         IBAN: iban,
         carrera,
         curso: cursoEstudios,
@@ -431,6 +437,9 @@ export default function SignUpProfesor() {
         NIF: nif,
         direccion_facturacion: direccionFacturacion,
         distrito,
+        barrio,
+        codigo_postal: codigoPostal,
+        ciudad,
         IBAN: iban,
         carrera,
         curso: cursoEstudios,
@@ -617,6 +626,30 @@ export default function SignUpProfesor() {
                     placeholder=" "
                   />
                   <label className="fl-label">Distrito facturación</label>
+                </div>
+              </Field>
+              <Field>
+                <div className="fl-field">
+                  <input
+                    className="form-control fl-input"
+                    type="text"
+                    value={barrio}
+                    onChange={e => setBarrio(e.target.value)}
+                    placeholder=" "
+                  />
+                  <label className="fl-label">Barrio</label>
+                </div>
+              </Field>
+              <Field>
+                <div className="fl-field">
+                  <input
+                    className="form-control fl-input"
+                    type="text"
+                    value={codigoPostal}
+                    onChange={e => setCodigoPostal(e.target.value)}
+                    placeholder=" "
+                  />
+                  <label className="fl-label">Código Postal</label>
                 </div>
               </Field>
               <Field>

--- a/src/screens/SignUpTutor.jsx
+++ b/src/screens/SignUpTutor.jsx
@@ -300,6 +300,8 @@ export default function SignUpTutor() {
   const [nifTutor, setNifTutor] = useState('');
   const [direccionTutor, setDireccionTutor] = useState('');
   const [distritoTutor, setDistritoTutor] = useState('');
+  const [barrioTutor, setBarrioTutor] = useState('');
+  const [codigoPostalTutor, setCodigoPostalTutor] = useState('');
   const [nifAlumno, setNifAlumno] = useState('');
   const [telefonoHijo, setTelefonoHijo] = useState('');
   const [confirmTelefonoHijo, setConfirmTelefonoHijo] = useState('');
@@ -390,6 +392,8 @@ export default function SignUpTutor() {
     if (!nifTutor) missing.push('NIF');
     if (!direccionTutor) missing.push('Dirección facturación');
     if (!distritoTutor) missing.push('Distrito facturación');
+    if (!barrioTutor) missing.push('Barrio facturación');
+    if (!codigoPostalTutor) missing.push('Código postal facturación');
     if (!nifAlumno) missing.push('NIF del Alumno');
     if (!telefonoHijo) missing.push('Teléfono del Alumno');
     if (!confirmTelefonoHijo) missing.push('Repite Teléfono del Alumno');
@@ -445,6 +449,8 @@ export default function SignUpTutor() {
         NIF: nifTutor,
         direccion: direccionTutor,
         distrito: distritoTutor,
+        barrio: barrioTutor,
+        codigo_postal: codigoPostalTutor,
         createdAt: new Date(),
         alumnos: [
           {
@@ -473,6 +479,10 @@ export default function SignUpTutor() {
           correo_electronico: email,
           NIF: nifTutor,
           direccion_facturacion: direccionTutor,
+          distrito: distritoTutor,
+          barrio: barrioTutor,
+          codigo_postal: codigoPostalTutor,
+          ciudad,
           password,
         },
         alumno: {
@@ -650,6 +660,30 @@ export default function SignUpTutor() {
                     placeholder=" "
                   />
                   <label className="fl-label">Distrito facturación</label>
+                </div>
+              </Field>
+              <Field>
+                <div className="fl-field">
+                  <input
+                    className="form-control fl-input"
+                    type="text"
+                    value={barrioTutor}
+                    onChange={e => setBarrioTutor(e.target.value)}
+                    placeholder=" "
+                  />
+                  <label className="fl-label">Barrio facturación</label>
+                </div>
+              </Field>
+              <Field>
+                <div className="fl-field">
+                  <input
+                    className="form-control fl-input"
+                    type="text"
+                    value={codigoPostalTutor}
+                    onChange={e => setCodigoPostalTutor(e.target.value)}
+                    placeholder=" "
+                  />
+                  <label className="fl-label">Código Postal facturación</label>
                 </div>
               </Field>
               <Field>


### PR DESCRIPTION
## Resumen
- Añadidos campos de barrio y código postal al formulario de alta de tutor.
- Añadidos campos de barrio y código postal al formulario de alta de profesor.
- Validaciones y envío de datos actualizados para incluir la nueva información de ubicación.

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689dcb4ba89c832b9efcbe9ac383caab