### PR TITLE
fix: centrar texto en campos de formulario

### DIFF
--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -15,12 +15,14 @@
 
 .fl-input{
   width:100%;
-  padding:1.1rem 1rem 0.6rem;
+  padding:0.75rem 1rem;
   border:1px solid transparent;
   border-radius:var(--radius);
   background:var(--bg-bubble);
   font-size:1rem;
   color:var(--text);
+  line-height:1;
+  text-align:center;
   transition:border-color var(--transition), box-shadow var(--transition), background var(--transition);
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,6 +9,12 @@
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
+input.form-control,
+textarea.form-control {
+  line-height: 1;
+  text-align: center;
+}
+
 /* Color corporativo para radios y checkboxes */
 input[type="radio"].form-control,
 input[type="checkbox"].form-control {


### PR DESCRIPTION
## Summary
- Alinea texto de inputs y textareas al centro para evitar desajustes verticales

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689dd0e1d9b0832bbda5d063f5eb51e9