### PR TITLE
Adjust floating input padding to prevent label overlap

### DIFF
--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -15,7 +15,8 @@
 
 .fl-input{
   width:100%;
-  padding:1.1rem 1rem 0.6rem;
+  /* increase top padding so typed text sits lower and doesn't collide with label */
+  padding:1.5rem 1rem 0.8rem;
   border:1px solid transparent;
   border-radius:var(--radius);
   background:var(--bg-bubble);


### PR DESCRIPTION
## Summary
- Increase top padding on floating text inputs so typed text sits lower and doesn't collide with the internal label

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dd2919850832b914d0427c3278360