### PR TITLE
Add class type to offers and default status

### DIFF
--- a/bbdd/sp_bbdd.sql
+++ b/bbdd/sp_bbdd.sql
@@ -190,6 +190,7 @@ CREATE TABLE IF NOT EXISTS student_project.oferta
     estado VARCHAR(100),
     numero_horas numeric NOT NULL,
     modalidad VARCHAR(100) NOT NULL,
+    tipo VARCHAR(100) NOT NULL,
     beneficio_sp numeric NOT NULL,
     ganancia_profesor numeric NOT NULL,
     precio_alumno numeric NOT NULL,

--- a/node-server/index.js
+++ b/node-server/index.js
@@ -221,6 +221,7 @@ app.post('/oferta', async (req, res) => {
     estado,
     numero_horas,
     modalidad,
+    tipo,
     beneficio_sp,
     ganancia_profesor,
     precio_alumno,
@@ -246,13 +247,14 @@ app.post('/oferta', async (req, res) => {
     const id_alumno = aRes.rows[0].id_alumno;
 
     const result = await client.query(
-      'INSERT INTO student_project.oferta (fecha_oferta, disponibilidad, estado, numero_horas, modalidad, beneficio_sp, ganancia_profesor, precio_alumno, precio_profesor, id_alumno) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) RETURNING id_oferta',
+      'INSERT INTO student_project.oferta (fecha_oferta, disponibilidad, estado, numero_horas, modalidad, tipo, beneficio_sp, ganancia_profesor, precio_alumno, precio_profesor, id_alumno) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11) RETURNING id_oferta',
       [
         fecha_oferta,
         disponibilidad,
         estado,
         numero_horas,
         modalidad,
+        tipo,
         beneficio_sp,
         ganancia_profesor,
         precio_alumno,

--- a/src/screens/alumno/acciones/NuevaClase.jsx
+++ b/src/screens/alumno/acciones/NuevaClase.jsx
@@ -523,9 +523,10 @@ export default function NuevaClase() {
       const ofertaRes = await createOferta({
         fecha_oferta: new Date().toISOString().slice(0,10),
         disponibilidad: Array.from(selectedSlots).join(','),
-        estado: 'pendiente',
+        estado: 'sin profesor',
         numero_horas: parseInt(horasSemana, 10),
         modalidad,
+        tipo: tipoClase,
         beneficio_sp: precioPadres - precioProfesores,
         ganancia_profesor: precioProfesores,
         precio_alumno: precioPadres,


### PR DESCRIPTION
## Summary
- Load request form into oferta with class type and default status without teacher
- Persist class type in backend and SQL schema

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a3b6218ce8832bb07f3de723684486