### PR TITLE
Add offer date range and track selected subjects and notes

### DIFF
--- a/bbdd/sp_bbdd.sql
+++ b/bbdd/sp_bbdd.sql
@@ -186,18 +186,23 @@ CREATE TABLE IF NOT EXISTS student_project.oferta
 (
     id_oferta serial PRIMARY KEY,
     fecha_oferta date NOT NULL,
+    fecha_inicio date NOT NULL,
+    fecha_fin date NOT NULL,
     disponibilidad VARCHAR(100) NOT NULL,
     estado VARCHAR(100),
     numero_horas numeric NOT NULL,
     modalidad VARCHAR(100) NOT NULL,
+    tipo VARCHAR(100) NOT NULL,
     beneficio_sp numeric NOT NULL,
     ganancia_profesor numeric NOT NULL,
     precio_alumno numeric NOT NULL,
     precio_profesor numeric NOT NULL,
+    asignaturas_seleccionadas TEXT NOT NULL,
+    anotaciones TEXT,
 
-	id_alumno INT NOT NULL REFERENCES student_project.alumno(id_alumno)
+        id_alumno INT NOT NULL REFERENCES student_project.alumno(id_alumno)
     ON DELETE RESTRICT
-    ON UPDATE CASCADE	
+    ON UPDATE CASCADE
 );
 
 COMMENT ON TABLE student_project.oferta

--- a/node-server/index.js
+++ b/node-server/index.js
@@ -217,10 +217,13 @@ app.post('/profesor', async (req, res) => {
 app.post('/oferta', async (req, res) => {
   const {
     fecha_oferta,
+    fecha_inicio,
+    fecha_fin,
     disponibilidad,
     estado,
     numero_horas,
     modalidad,
+    tipo,
     beneficio_sp,
     ganancia_profesor,
     precio_alumno,
@@ -229,6 +232,7 @@ app.post('/oferta', async (req, res) => {
     alumno_nombre,
     alumno_apellidos,
     asignaturas = [],
+    anotaciones,
   } = req.body;
 
   let client;
@@ -246,17 +250,22 @@ app.post('/oferta', async (req, res) => {
     const id_alumno = aRes.rows[0].id_alumno;
 
     const result = await client.query(
-      'INSERT INTO student_project.oferta (fecha_oferta, disponibilidad, estado, numero_horas, modalidad, beneficio_sp, ganancia_profesor, precio_alumno, precio_profesor, id_alumno) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) RETURNING id_oferta',
+      'INSERT INTO student_project.oferta (fecha_oferta, fecha_inicio, fecha_fin, disponibilidad, estado, numero_horas, modalidad, tipo, beneficio_sp, ganancia_profesor, precio_alumno, precio_profesor, asignaturas_seleccionadas, anotaciones, id_alumno) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15) RETURNING id_oferta',
       [
         fecha_oferta,
+        fecha_inicio,
+        fecha_fin,
         disponibilidad,
         estado,
         numero_horas,
         modalidad,
+        tipo,
         beneficio_sp,
         ganancia_profesor,
         precio_alumno,
         precio_profesor,
+        asignaturas.join(','),
+        anotaciones || null,
         id_alumno,
       ]
     );

--- a/src/screens/alumno/acciones/NuevaClase.jsx
+++ b/src/screens/alumno/acciones/NuevaClase.jsx
@@ -522,10 +522,13 @@ export default function NuevaClase() {
     try {
       const ofertaRes = await createOferta({
         fecha_oferta: new Date().toISOString().slice(0,10),
+        fecha_inicio: startDate,
+        fecha_fin: endDate,
         disponibilidad: Array.from(selectedSlots).join(','),
-        estado: 'pendiente',
+        estado: 'En búsqueda de profesor',
         numero_horas: parseInt(horasSemana, 10),
         modalidad,
+        tipo: tipoClase,
         beneficio_sp: precioPadres - precioProfesores,
         ganancia_profesor: precioProfesores,
         precio_alumno: precioPadres,
@@ -534,6 +537,7 @@ export default function NuevaClase() {
         alumno_nombre: alumnoNombre,
         alumno_apellidos: alumnoApellidos,
         asignaturas,
+        anotaciones: notas,
       });
 
       await addDoc(collection(db,'clases'), {
@@ -556,7 +560,7 @@ export default function NuevaClase() {
         precioPadres,
         precioProfesores,
         notas,
-        estado: 'pendiente',
+        estado: 'En búsqueda de profesor',
         ofertaId: ofertaRes.id,
         createdAt: serverTimestamp()
       });


### PR DESCRIPTION
## Summary
- Capture start and end dates for offers and store them in Postgres
- Insert offers with "En búsqueda de profesor" status
- Store selected subjects and tutor notes in new Postgres columns
- Send notes and subject list from the request form to backend

## Testing
- `CI=true npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a3b6218ce8832bb07f3de723684486