### PR TITLE
Center verified email message

### DIFF
--- a/src/screens/SignUpProfesor.jsx
+++ b/src/screens/SignUpProfesor.jsx
@@ -543,7 +543,11 @@ export default function SignUpProfesor() {
                   />
                   <VerifyButton type="button" onClick={handleCheckCode} status={checkStatus}>Comprobar</VerifyButton>
                 </VerificationRow>
-                {emailVerified && <p style={{color:'#046654',fontSize:'0.9rem'}}>Correo verificado</p>}
+                {emailVerified && (
+                  <p style={{ color: '#046654', fontSize: '0.9rem', textAlign: 'center' }}>
+                    Correo verificado
+                  </p>
+                )}
               </Field>
             </FormColumn>
             <Button onClick={() => setStep(2)} disabled={!emailVerified || !password || !confirmPassword || password !== confirmPassword}>

--- a/src/screens/SignUpTutor.jsx
+++ b/src/screens/SignUpTutor.jsx
@@ -595,7 +595,11 @@ export default function SignUpTutor() {
                   />
                   <VerifyButton type="button" onClick={handleCheckCode} status={checkStatus}>Comprobar</VerifyButton>
                 </VerificationRow>
-                {emailVerified && <p style={{color:'#046654',fontSize:'0.9rem'}}>Correo verificado</p>}
+                {emailVerified && (
+                  <p style={{ color: '#046654', fontSize: '0.9rem', textAlign: 'center' }}>
+                    Correo verificado
+                  </p>
+                )}
               </Field>
             </FormColumn>
             <Button onClick={() => setStep(2)} disabled={!emailVerified || !password || !confirmPwd || password !== confirmPwd}>


### PR DESCRIPTION
## Summary
- center the "Correo verificado" success message in tutor and profesor signup forms

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a738e64704832bb357d00cd223e414