### PR TITLE
feat: expand tutor child form for full student registration

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -44,6 +44,15 @@ export async function registerTutor(data) {
   return handleResponse(res);
 }
 
+export async function registerAlumno(data) {
+  const res = await fetch(`${API_URL}/alumno`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  return handleResponse(res);
+}
+
 export async function registerProfesor(data) {
   const res = await fetch(`${API_URL}/profesor`, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- allow tutors to add children with complete details from modal
- persist new students in PostgreSQL via new `/alumno` endpoint
- expose `registerAlumno` API helper

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a73a4cbe40832b8c84fda39c65d128