### PR TITLE
Delay teacher personal details until first-class bid

### DIFF
--- a/node-server/index.js
+++ b/node-server/index.js
@@ -253,12 +253,12 @@ app.post('/profesor', async (req, res) => {
     genero,
     telefono,
     correo_electronico,
-    NIF,
+    NIF = null,
     direccion_facturacion,
-    IBAN,
-    carrera,
-    curso,
-    experiencia,
+    IBAN = null,
+    carrera = null,
+    curso = null,
+    experiencia = null,
     password,
   } = req.body;
   try {

--- a/src/components/CompleteTeacherProfileModal.jsx
+++ b/src/components/CompleteTeacherProfileModal.jsx
@@ -81,7 +81,11 @@ const ErrorText = styled.p`
 export default function CompleteTeacherProfileModal({ open, onClose, userData }) {
   const { refreshUserData } = useAuth();
   const [docSelect, setDocSelect] = useState(
-    userData?.docType === 'DNI' ? 'DNI' : 'Otro'
+    userData?.docType
+      ? userData.docType === 'DNI'
+        ? 'DNI'
+        : 'Otro'
+      : ''
   );
   const [docTypeOther, setDocTypeOther] = useState(
     userData?.docType && userData?.docType !== 'DNI' ? userData.docType : ''
@@ -152,6 +156,7 @@ export default function CompleteTeacherProfileModal({ open, onClose, userData })
             onChange={e => setDocSelect(e.target.value)}
             disabled={!!userData?.docNumber}
           >
+            <option value="">Seleccione tipo de documento</option>
             <option value="DNI">DNI</option>
             <option value="Otro">Otro</option>
           </SelectInput>
@@ -172,7 +177,7 @@ export default function CompleteTeacherProfileModal({ open, onClose, userData })
             type="text"
             value={docNumber}
             onChange={e => setDocNumber(e.target.value)}
-            disabled={!!userData?.docNumber}
+            disabled={!!userData?.docNumber || !docSelect}
           />
           {dniError && <ErrorText>{dniError}</ErrorText>}
         </Field>

--- a/src/screens/SignUpProfesor.jsx
+++ b/src/screens/SignUpProfesor.jsx
@@ -301,15 +301,10 @@ export default function SignUpProfesor() {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [modalOpen, setModalOpen]     = useState(false);
   const [submitting, setSubmitting] = useState(false);
-  const [nif, setNif] = useState('');
   const [direccionFacturacion, setDireccionFacturacion] = useState('');
   const [distrito, setDistrito] = useState('');
   const [barrio, setBarrio] = useState('');
   const [codigoPostal, setCodigoPostal] = useState('');
-  const [iban, setIban] = useState('');
-  const [carrera, setCarrera] = useState('');
-  const [cursoEstudios, setCursoEstudios] = useState('');
-  const [experiencia, setExperiencia] = useState('');
   const navigate = useNavigate();
   const { show } = useNotification();
   const ref = useRef();
@@ -382,15 +377,10 @@ export default function SignUpProfesor() {
     if (!telefono) missing.push('Teléfono');
     if (!confirmTelefono) missing.push('Repite Teléfono');
     if (!ciudad) missing.push('Ciudad');
-    if (!nif) missing.push('NIF');
     if (!direccionFacturacion) missing.push('Dirección facturación');
     if (!distrito) missing.push('Distrito');
     if (!barrio) missing.push('Barrio');
     if (!codigoPostal) missing.push('Código Postal');
-    if (!iban) missing.push('IBAN');
-    if (!carrera) missing.push('Carrera');
-    if (!cursoEstudios) missing.push('Curso');
-    if (!experiencia) missing.push('Experiencia');
     if (!emailVerified) missing.push('Verificación de correo');
     if (missing.length) {
       show('Faltan: ' + missing.join(', '), 'error');
@@ -429,15 +419,15 @@ export default function SignUpProfesor() {
         ciudad,
         rol: 'profesor',
         createdAt: new Date(),
-        NIF: nif,
+        NIF: null,
         direccion: direccionFacturacion,
         distrito,
         barrio,
         codigo_postal: codigoPostal,
-        IBAN: iban,
-        carrera,
-        curso: cursoEstudios,
-        experiencia,
+        IBAN: null,
+        carrera: null,
+        curso: null,
+        experiencia: null,
       });
       const genero = salutation === 'Sr.' ? 'Masculino' : 'Femenino';
       await registerProfesor({
@@ -446,16 +436,16 @@ export default function SignUpProfesor() {
         genero,
         telefono,
         correo_electronico: email,
-        NIF: nif,
+        NIF: null,
         direccion_facturacion: direccionFacturacion,
         distrito,
         barrio,
         codigo_postal: codigoPostal,
         ciudad,
-        IBAN: iban,
-        carrera,
-        curso: cursoEstudios,
-        experiencia,
+        IBAN: null,
+        carrera: null,
+        curso: null,
+        experiencia: null,
         password,
       });
       await sendWelcomeEmail({ email, name: nombre });
@@ -613,18 +603,6 @@ export default function SignUpProfesor() {
                   <input
                     className="form-control fl-input"
                     type="text"
-                    value={nif}
-                    onChange={e => setNif(e.target.value)}
-                    placeholder=" "
-                  />
-                  <label className="fl-label">NIF</label>
-                </div>
-              </Field>
-              <Field>
-                <div className="fl-field">
-                  <input
-                    className="form-control fl-input"
-                    type="text"
                     value={direccionFacturacion}
                     onChange={e => setDireccionFacturacion(e.target.value)}
                     placeholder=" "
@@ -666,54 +644,6 @@ export default function SignUpProfesor() {
                     placeholder=" "
                   />
                   <label className="fl-label">Código Postal</label>
-                </div>
-              </Field>
-              <Field>
-                <div className="fl-field">
-                  <input
-                    className="form-control fl-input"
-                    type="text"
-                    value={iban}
-                    onChange={e => setIban(e.target.value)}
-                    placeholder=" "
-                  />
-                  <label className="fl-label">IBAN</label>
-                </div>
-              </Field>
-              <Field>
-                <div className="fl-field">
-                  <input
-                    className="form-control fl-input"
-                    type="text"
-                    value={carrera}
-                    onChange={e => setCarrera(e.target.value)}
-                    placeholder=" "
-                  />
-                  <label className="fl-label">Carrera</label>
-                </div>
-              </Field>
-              <Field>
-                <div className="fl-field">
-                  <input
-                    className="form-control fl-input"
-                    type="text"
-                    value={cursoEstudios}
-                    onChange={e => setCursoEstudios(e.target.value)}
-                    placeholder=" "
-                  />
-                  <label className="fl-label">Curso</label>
-                </div>
-              </Field>
-              <Field style={{ gridColumn: '1 / -1' }}>
-                <div className="fl-field">
-                  <input
-                    className="form-control fl-input"
-                    type="text"
-                    value={experiencia}
-                    onChange={e => setExperiencia(e.target.value)}
-                    placeholder=" "
-                  />
-                  <label className="fl-label">Experiencia</label>
                 </div>
               </Field>
               <Field style={{ gridColumn: '1 / -1' }} ref={ref}>


### PR DESCRIPTION
## Summary
- Remove IBAN, NIF and study-related fields from professor signup; store them as null until bidding
- Default document type selection to an empty choice and disable number input until selected
- Allow backend to accept null personal data during professor creation

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a73b8580b0832b89df7435a9578ab2