### PR TITLE
Improve modal aesthetics and profile layout

### DIFF
--- a/src/components/AddChildModal.jsx
+++ b/src/components/AddChildModal.jsx
@@ -6,29 +6,7 @@ import { doc, updateDoc } from 'firebase/firestore';
 import { useChild } from '../ChildContext';
 import { useAuth } from '../AuthContext';
 import { fetchCursos, registerAlumno } from '../utils/api';
-
-const Overlay = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0,0,0,0.4);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1500;
-`;
-
-const Modal = styled.div`
-  background: #fff;
-  border-radius: 10px;
-  padding: 2rem 1.5rem;
-  width: 100%;
-  max-width: 420px;
-  box-shadow: 0 12px 36px rgba(0,0,0,0.2);
-  position: relative;
-`;
+import { Overlay, Modal, ModalTitle } from './ModalStyles';
 
 const CloseButton = styled.button`
   position: absolute;
@@ -38,11 +16,6 @@ const CloseButton = styled.button`
   border: none;
   font-size: 1.25rem;
   cursor: pointer;
-`;
-
-const Title = styled.h2`
-  margin: 0 0 1rem;
-  color: #014F40;
 `;
 
 
@@ -154,7 +127,7 @@ export default function AddChildModal({ open, onClose }) {
     <Overlay onClick={onClose}>
       <Modal onClick={e => e.stopPropagation()}>
         <CloseButton onClick={onClose}>✕</CloseButton>
-        <Title>Añadir alumno</Title>
+        <ModalTitle>Añadir alumno</ModalTitle>
         <TextInput
           type="text"
           placeholder="Nombre"

--- a/src/components/CompleteTeacherProfileModal.jsx
+++ b/src/components/CompleteTeacherProfileModal.jsx
@@ -4,6 +4,7 @@ import { TextInput, SelectInput, PrimaryButton } from './FormElements';
 import { auth, db } from '../firebase/firebaseConfig';
 import { doc, updateDoc } from 'firebase/firestore';
 import { useAuth } from '../AuthContext';
+import { Overlay, Modal, ModalTitle } from './ModalStyles';
 
 const DNI_LETTERS = 'TRWAGMYFPDXBNJZSQVHLCKE';
 
@@ -30,29 +31,6 @@ function validateIBAN(value) {
   return remainder === 1;
 }
 
-const Overlay = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0,0,0,0.4);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1500;
-`;
-
-const Modal = styled.div`
-  background: #fff;
-  border-radius: 10px;
-  padding: 2rem 1.5rem;
-  width: 100%;
-  max-width: 480px;
-  box-shadow: 0 12px 36px rgba(0,0,0,0.2);
-  position: relative;
-`;
-
 const CloseButton = styled.button`
   position: absolute;
   top: 0.5rem;
@@ -61,11 +39,6 @@ const CloseButton = styled.button`
   border: none;
   font-size: 1.25rem;
   cursor: pointer;
-`;
-
-const Title = styled.h2`
-  margin: 0 0 1rem;
-  color: #014F40;
 `;
 
 const Field = styled.div`
@@ -148,7 +121,7 @@ export default function CompleteTeacherProfileModal({ open, onClose, userData })
     <Overlay onClick={onClose}>
       <Modal onClick={e => e.stopPropagation()}>
         <CloseButton onClick={onClose}>✕</CloseButton>
-        <Title>Completa tu perfil</Title>
+        <ModalTitle>Completa tu perfil</ModalTitle>
         <Field>
           <label>Tipo de documento</label>
           <SelectInput

--- a/src/components/InfoGrid.jsx
+++ b/src/components/InfoGrid.jsx
@@ -3,8 +3,30 @@ import styled from 'styled-components';
 const InfoGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 0.75rem 2rem;
+  gap: 1rem;
   margin-bottom: 1rem;
+
+  > div {
+    background: #fff;
+    border-radius: 12px;
+    padding: 0.75rem 1rem;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+    display: flex;
+    flex-direction: column;
+  }
+
+  > div > span:first-child {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #666;
+    margin-bottom: 0.25rem;
+  }
+
+  > div > span:last-child {
+    color: #014F40;
+    font-weight: 600;
+  }
 `;
 
 export default InfoGrid;

--- a/src/components/ModalStyles.js
+++ b/src/components/ModalStyles.js
@@ -1,0 +1,71 @@
+import styled from 'styled-components';
+
+export const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.55);
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1500;
+`;
+
+export const Modal = styled.div`
+  background: #fff;
+  border-radius: 12px;
+  padding: 2rem 1.5rem;
+  width: 100%;
+  max-width: 480px;
+  box-shadow: 0 20px 40px rgba(0,0,0,0.2);
+  animation: slideDown 0.3s ease forwards;
+  position: relative;
+
+  @keyframes slideDown {
+    from {
+      opacity: 0;
+      transform: translateY(-15px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+`;
+
+export const ModalTitle = styled.h2`
+  margin-top: 0;
+  margin-bottom: 1rem;
+  text-align: center;
+  color: #014F40;
+`;
+
+export const ModalText = styled.p`
+  margin-bottom: 1.5rem;
+  font-size: 1.1rem;
+  color: #014F40;
+  text-align: center;
+`;
+
+export const ModalActions = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  margin-top: 1.5rem;
+`;
+
+export const ModalButton = styled.button`
+  padding: 0.7rem 1.4rem;
+  border: none;
+  border-radius: 6px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.3s;
+  ${p =>
+    p.primary
+      ? `background: #046654; color: #fff; &:hover { background: #034640; }`
+      : `background: #e9e9e9; color: #333; &:hover { background: #d4d4d4; }`};
+`;

--- a/src/components/PasswordChangeModal.jsx
+++ b/src/components/PasswordChangeModal.jsx
@@ -2,30 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { resetPassword } from '../utils/password';
 import logo from '../assets/logonavbar.png';
-
-const Overlay = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0,0,0,0.4);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1500;
-`;
-
-const Modal = styled.div`
-  background: #fff;
-  border-radius: 10px;
-  padding: 2rem 1.5rem;
-  width: 100%;
-  max-width: 420px;
-  text-align: center;
-  box-shadow: 0 12px 36px rgba(0,0,0,0.2);
-  position: relative;
-`;
+import { Overlay, Modal, ModalTitle } from './ModalStyles';
 
 const CloseButton = styled.button`
   position: absolute;
@@ -42,10 +19,6 @@ const Logo = styled.img`
   margin: 0 auto 1rem;
 `;
 
-const Title = styled.h2`
-  margin: 0 0 1rem;
-  color: #014F40;
-`;
 
 const Input = styled.input`
   width: 100%;
@@ -121,7 +94,7 @@ export default function PasswordChangeModal({ open, onClose, token }) {
       <Modal onClick={e => e.stopPropagation()}>
         <CloseButton onClick={onClose}>✕</CloseButton>
         <Logo src={logo} alt="Student Project" />
-        <Title>Cambiar contraseña</Title>
+        <ModalTitle>Cambiar contraseña</ModalTitle>
         {error && <ErrorText>{error}</ErrorText>}
         {success && <SuccessText>{success}</SuccessText>}
         <form onSubmit={handleSubmit}>

--- a/src/components/PasswordResetModal.jsx
+++ b/src/components/PasswordResetModal.jsx
@@ -3,30 +3,7 @@ import styled from 'styled-components';
 import { requestPasswordReset } from '../utils/password';
 
 import logo from '../assets/logonavbar.png';
-
-const Overlay = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0,0,0,0.4);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1500;
-`;
-
-const Modal = styled.div`
-  background: #fff;
-  border-radius: 10px;
-  padding: 2rem 1.5rem;
-  width: 100%;
-  max-width: 420px;
-  text-align: center;
-  box-shadow: 0 12px 36px rgba(0,0,0,0.2);
-  position: relative;
-`;
+import { Overlay, Modal, ModalTitle } from './ModalStyles';
 
 const CloseButton = styled.button`
   position: absolute;
@@ -43,10 +20,6 @@ const Logo = styled.img`
   margin: 0 auto 1rem;
 `;
 
-const Title = styled.h2`
-  margin: 0 0 1rem;
-  color: #014F40;
-`;
 
 const Input = styled.input`
   width: 100%;
@@ -111,7 +84,7 @@ export default function PasswordResetModal({ open, onClose }) {
       <Modal>
         <CloseButton onClick={onClose}>✕</CloseButton>
         <Logo src={logo} alt="Student Project" />
-        <Title>Restablecer contraseña</Title>
+        <ModalTitle>Restablecer contraseña</ModalTitle>
         {error && <ErrorText>{error}</ErrorText>}
         {success && <SuccessText>{success}</SuccessText>}
         <form onSubmit={handleSubmit}>

--- a/src/screens/SignUpProfesor.jsx
+++ b/src/screens/SignUpProfesor.jsx
@@ -8,6 +8,7 @@ import { sendWelcomeEmail, sendVerificationCode } from '../utils/email';
 import { fetchCities, registerProfesor } from '../utils/api';
 import PhoneInput from 'react-phone-input-2';
 import 'react-phone-input-2/lib/style.css';
+import { Overlay, Modal, ModalText, ModalActions, ModalButton } from '../components/ModalStyles';
 
 // Firebase (inicializado en firebaseConfig.js)
 import { auth, db } from '../firebase/firebaseConfig';
@@ -239,45 +240,6 @@ const Button = styled.button`
 `;
 
 // Popup overlay y modal
-const Overlay = styled.div`
-  position: fixed;
-  top: 0; left: 0; right: 0; bottom: 0;
-  background: rgba(0,0,0,0.4);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 100;
-`;
-const Modal = styled.div`
-  background: #fff;
-  border-radius: 10px;
-  padding: 2rem;
-  max-width: 400px;
-  text-align: center;
-  box-shadow: 0 12px 36px rgba(0,0,0,0.2);
-`;
-const ModalText = styled.p`
-  margin-bottom: 1.5rem;
-  font-size: 1.1rem;
-  color: #014F40;
-`;
-const ModalActions = styled.div`
-  display: flex;
-  justify-content: space-around;
-  gap: 1.5rem;
-`;
-const ModalButton = styled.button`
-  padding: 0.8rem 1.5rem;
-  border: none;
-  border-radius: 6px;
-  font-size: 1rem;
-  cursor: pointer;
-  transition: background 0.3s;
-  ${props => props.primary
-    ? `background: #046654; color: #fff; &:hover { background: #034640; }`
-    : `background: #eee; color: #333; &:hover { background: #ddd; }`
-  }
-`;
 
 export default function SignUpProfesor() {
   const [email, setEmail]             = useState('');

--- a/src/screens/SignUpTutor.jsx
+++ b/src/screens/SignUpTutor.jsx
@@ -12,6 +12,7 @@ import {
 } from '../utils/api';
 import PhoneInput from 'react-phone-input-2';
 import 'react-phone-input-2/lib/style.css';
+import { Overlay, Modal, ModalText, ModalActions, ModalButton } from '../components/ModalStyles';
 
 // Firebase (inicializado en firebaseConfig.js)
 import { auth, db } from '../firebase/firebaseConfig';
@@ -248,42 +249,6 @@ const Button = styled.button`
 `;
 
 // Popup modal
-const Overlay = styled.div`
-  position: fixed; top: 0; left: 0; right: 0; bottom: 0;
-  background: rgba(0,0,0,0.4);
-  display: flex; align-items: center; justify-content: center;
-  z-index: 100;
-`;
-const Modal = styled.div`
-  background: #fff;
-  border-radius: 10px;
-  padding: 2rem;
-  max-width: 400px;
-  text-align: center;
-  box-shadow: 0 12px 36px rgba(0,0,0,0.2);
-`;
-const ModalText = styled.p`
-  margin-bottom: 1.5rem;
-  font-size: 1.1rem;
-  color: #014F40;
-`;
-const ModalActions = styled.div`
-  display: flex;
-  justify-content: space-around;
-  gap: 1.5rem;
-`;
-const ModalButton = styled.button`
-  padding: 0.8rem 1.5rem;
-  border: none;
-  border-radius: 6px;
-  font-size: 1rem;
-  cursor: pointer;
-  transition: background 0.3s;
-  ${p => p.primary
-    ? `background: #046654; color: #fff; &:hover { background: #034640; }`
-    : `background: #eee; color: #333; &:hover { background: #ddd; }`
-  }
-`;
 
 export default function SignUpTutor() {
   const [email, setEmail]           = useState('');

--- a/src/screens/admin/acciones/GestionClases.jsx
+++ b/src/screens/admin/acciones/GestionClases.jsx
@@ -18,6 +18,7 @@ import {
 } from 'firebase/firestore';
 import { sendAssignmentEmails } from '../../../utils/email';
 import { registerPendingClass } from '../../../utils/classWorkflow';
+import { Overlay, Modal, ModalText, ModalActions, ModalButton } from '../../../components/ModalStyles';
 
 // Animación suave al cargar
 const fadeDown = keyframes`
@@ -169,39 +170,6 @@ function calculateWeeks(startStr, endStr) {
 }
 
 // ----- Modal de confirmación -----
-const Overlay = styled.div`
-  position: fixed; inset: 0;
-  background: rgba(0,0,0,0.4);
-  display: flex; align-items: center; justify-content: center;
-  z-index: 100;
-`;
-const Modal = styled.div`
-  background: #fff;
-  border-radius: 8px;
-  padding: 1.5rem;
-  max-width: 320px;
-  text-align: center;
-`;
-const ModalText = styled.p`
-  font-size: 1rem;
-  margin-bottom: 1rem;
-  color: #014F40;
-`;
-const ModalActions = styled.div`
-  display: flex;
-  justify-content: space-around;
-`;
-const ModalButton = styled.button`
-  padding: 0.6rem 1.2rem;
-  border: none;
-  border-radius: 6px;
-  font-size: 0.9rem;
-  cursor: pointer;
-  ${p => p.primary
-    ? `background: #006D5B; color: #fff;`
-    : `background: #f0f0f0; color: #333;`
-  }
-`;
 
 export default function GestionClases() {
   const [clases, setClases] = useState([]);

--- a/src/screens/alumno/acciones/MisAlumnos.jsx
+++ b/src/screens/alumno/acciones/MisAlumnos.jsx
@@ -5,6 +5,7 @@ import { auth, db } from '../../../firebase/firebaseConfig';
 import { doc, updateDoc } from 'firebase/firestore';
 import { useChild } from '../../../ChildContext';
 import { useAuth } from '../../../AuthContext';
+import { Overlay, Modal, ModalText, ModalActions, ModalButton } from '../../../components/ModalStyles';
 
 const fadeIn = keyframes`
   from { opacity: 0; transform: translateY(-10px); }
@@ -60,43 +61,6 @@ const Form = styled.div`
   border-radius: 8px;
 `;
 
-const Overlay = styled.div`
-  position: fixed; inset: 0;
-  background: rgba(0,0,0,0.4);
-  display: flex; align-items: center; justify-content: center;
-  z-index: 100;
-`;
-
-const Modal = styled.div`
-  background: #fff;
-  border-radius: 8px;
-  padding: 1.5rem;
-  max-width: 320px;
-  text-align: center;
-`;
-
-const ModalText = styled.p`
-  font-size: 1rem;
-  margin-bottom: 1rem;
-  color: #014F40;
-`;
-
-const ModalActions = styled.div`
-  display: flex;
-  justify-content: space-around;
-`;
-
-const ModalButton = styled.button`
-  padding: 0.6rem 1.2rem;
-  border: none;
-  border-radius: 6px;
-  font-size: 0.9rem;
-  cursor: pointer;
-  ${p =>
-    p.primary
-      ? `background: #006D5B; color: #fff;`
-      : `background: #f0f0f0; color: #333;`}
-`;
 
 export default function MisAlumnos() {
   const { childList, setChildList, setSelectedChild } = useChild();

--- a/src/screens/alumno/acciones/NuevaClase.jsx
+++ b/src/screens/alumno/acciones/NuevaClase.jsx
@@ -14,6 +14,7 @@ import {
   doc
 } from 'firebase/firestore';
 import { fetchCities, fetchCursos, fetchAsignaturas, createOferta, fetchPagos } from '../../../utils/api';
+import { Overlay, Modal, ModalText, ModalActions, ModalButton } from '../../../components/ModalStyles';
 
 // Animación fade-in
 const fadeIn = keyframes`
@@ -228,41 +229,7 @@ const SlotCell = styled.div`
   opacity: ${p => (p.disabled ? 0.6 : 1)};
   pointer-events: ${p => (p.disabled ? 'none' : 'auto')};
 `;
-const Overlay = styled.div`
-  position: fixed; inset: 0;
-  background: rgba(0,0,0,0.4);
-  display: flex; align-items: center; justify-content: center;
-  z-index: 100;
-`;
-const Modal = styled.div`
-  background: #fff;
-  border-radius: 8px;
-  padding: 1.5rem;
-  max-width: 320px;
-  text-align: center;
-`;
-const ModalText = styled.p`
-  font-size: 1rem;
-  margin-bottom: 1rem;
-  color: #014F40;
-`;
-const ModalActions = styled.div`
-  display: flex;
-  justify-content: space-around;
-`;
-const ModalButton = styled.button`
-  padding: 0.6rem 1.2rem;
-  border: none;
-  border-radius: 6px;
-  font-size: 0.9rem;
-  cursor: pointer;
-  opacity: ${p => (p.disabled ? 0.6 : 1)};
-  pointer-events: ${p => (p.disabled ? 'none' : 'auto')};
-  ${p => p.primary
-    ? `background: #006D5B; color: #fff;`
-    : `background: #f0f0f0; color: #333;`
-  }
-`;
+
 
 // Utilidad para obtener la fecha de hoy en formato YYYY-MM-DD
 const getToday = () => new Date().toISOString().split('T')[0];

--- a/src/screens/profesor/acciones/Ofertas.jsx
+++ b/src/screens/profesor/acciones/Ofertas.jsx
@@ -18,6 +18,7 @@ import {
   getDoc
 } from 'firebase/firestore';
 import { createPuja } from '../../../utils/api';
+import { Overlay, Modal, ModalText, ModalActions, ModalButton } from '../../../components/ModalStyles';
 
 // Animación de fade-in al desplegar
 const fadeDown = keyframes`
@@ -319,59 +320,6 @@ const RequestButton = styled.button`
 `;
 
 // Modal de confirmación con estilo profesional
-const Overlay = styled.div`
-  position: fixed; inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  display: flex; align-items: center; justify-content: center;
-  z-index: 100;
-`;
-const Modal = styled.div`
-  background: #ffffff;
-  border-radius: 12px;
-  padding: 2rem;
-  max-width: 440px;
-  width: 90%;
-  text-align: left;
-  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.15);
-`;
-const ModalText = styled.div`
-  font-size: 1rem;
-  color: #014F40;
-  margin-bottom: 1.5rem;
-  line-height: 1.5;
-`;
-const ModalActions = styled.div`
-  display: flex;
-  justify-content: space-around;
-  gap: 1rem;
-`;
-const ModalButton = styled.button`
-  flex: 1;
-  padding: 0.75rem;
-  border: none;
-  border-radius: 8px;
-  font-size: 1rem;
-  cursor: pointer;
-  transition: background 0.2s, box-shadow 0.2s;
-  ${p => p.primary
-    ? `
-      background: #006D5B;
-      color: #fff;
-      &:hover {
-        background: #005047;
-        box-shadow: 0 6px 18px rgba(0, 0, 0, 0.1);
-      }
-    `
-    : `
-      background: #f0f0f0;
-      color: #333;
-      &:hover {
-        background: #e0e0e0;
-        box-shadow: 0 6px 18px rgba(0, 0, 0, 0.05);
-      }
-    `
-  }
-`;
 
 // Calendario pequeño para selección de franjas
 const SmallCalendarContainer = styled.div`

--- a/src/screens/shared/Perfil.jsx
+++ b/src/screens/shared/Perfil.jsx
@@ -617,24 +617,27 @@ export default function Perfil() {
                   <InfoGrid>
                     {profile.telefono && (
                       <div>
-                        <Label>Teléfono:</Label> <Value>{profile.telefono}</Value>
+                        <Label>Teléfono</Label>
+                        <Value>{profile.telefono}</Value>
                       </div>
                     )}
                     {profile.ciudad && (
                       <div>
-                        <Label>Ciudad:</Label> <Value>{profile.ciudad}</Value>
+                        <Label>Ciudad</Label>
+                        <Value>{profile.ciudad}</Value>
                       </div>
                     )}
                     {role === 'profesor' && profile.studies && (
                       <div>
-                        <Label>Estudios:</Label> <Value>{profile.studies}</Value>
+                        <Label>Estudios</Label>
+                        <Value>{profile.studies}</Value>
                       </div>
                     )}
                     {role === 'profesor' &&
                       profile.studyTime &&
                       profile.status !== 'trabaja' && (
                         <div>
-                          <Label>Tiempo estudiando:</Label>{' '}
+                          <Label>Tiempo estudiando</Label>
                           <Value>{profile.studyTime}</Value>
                         </div>
                       )}
@@ -642,7 +645,7 @@ export default function Perfil() {
                       profile.careerFinished !== undefined &&
                       profile.careerFinished !== null && (
                         <div>
-                          <Label>Carrera finalizada:</Label>{' '}
+                          <Label>Carrera finalizada</Label>
                           <Value>{profile.careerFinished ? 'Sí' : 'No'}</Value>
                         </div>
                       )}
@@ -650,12 +653,13 @@ export default function Perfil() {
                       profile.job &&
                       profile.status === 'trabaja' && (
                         <div>
-                          <Label>Trabajo:</Label> <Value>{profile.job}</Value>
+                          <Label>Trabajo</Label>
+                          <Value>{profile.job}</Value>
                         </div>
                       )}
                     {role === 'profesor' && profile.status && (
                       <div>
-                        <Label>Situación:</Label>{' '}
+                        <Label>Situación</Label>
                         <Value>
                           {profile.status === 'estudia' ? 'Estudia' : 'Trabaja'}
                         </Value>
@@ -663,7 +667,8 @@ export default function Perfil() {
                     )}
                     {role === 'profesor' && profile.iban && (
                       <div>
-                        <Label>IBAN:</Label> <Value>{profile.iban}</Value>
+                        <Label>IBAN</Label>
+                        <Value>{profile.iban}</Value>
                       </div>
                     )}
                   </InfoGrid>


### PR DESCRIPTION
## Summary
- Introduce shared styled modal components for consistent professional popups
- Apply new modal design across sign up flows and common dialogs
- Refresh profile information cards for clearer visual presentation

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a74088e490832b87177e124853bdc4