### PR TITLE
Fix undefined variables in AddChildModal

### DIFF
--- a/src/components/AddChildModal.jsx
+++ b/src/components/AddChildModal.jsx
@@ -84,7 +84,7 @@ export default function AddChildModal({ open, onClose }) {
         id: Date.now().toString(),
         nombre: name,
         apellidos: lastName,
-        genero,
+        genero: gender,
         fechaNacimiento: date,
         curso: courseName,
         telefono: phone,
@@ -93,7 +93,7 @@ export default function AddChildModal({ open, onClose }) {
         distrito: district,
         barrio,
         codigo_postal: postalCode,
-        ciudad,
+        ciudad: city,
         photoURL: userData?.photoURL || auth.currentUser.photoURL || ''
       };
       const nuevos = [...childList, nuevo];


### PR DESCRIPTION
## Summary
- use gender and city state variables when constructing new child object

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68a7597b1678832ba576a202d3b08351