### PR TITLE
Center modal action buttons

### DIFF
--- a/src/components/ModalStyles.js
+++ b/src/components/ModalStyles.js
@@ -52,7 +52,7 @@ export const ModalText = styled.p`
 
 export const ModalActions = styled.div`
   display: flex;
-  justify-content: flex-end;
+  justify-content: center;
   gap: 1rem;
   margin-top: 1.5rem;
 `;

--- a/src/screens/profesor/acciones/Clases.jsx
+++ b/src/screens/profesor/acciones/Clases.jsx
@@ -166,7 +166,8 @@ const Input = styled.input`
 
 const ModalActions = styled.div`
   display: flex;
-  justify-content: space-around;
+  justify-content: center;
+  gap: 1rem;
 `;
 
 const ModalButton = styled.button`

--- a/src/screens/profesor/acciones/MisAlumnos.jsx
+++ b/src/screens/profesor/acciones/MisAlumnos.jsx
@@ -247,13 +247,13 @@ const Select = styled.select`
 
 const ModalActions = styled.div`
   display: flex;
-  justify-content: space-around;
+  justify-content: center;
+  gap: 1rem;
   padding: 0.75rem 1rem;
   border-top: 1px solid #eee;
 `;
 
 const ModalButton = styled.button`
-  flex: 1;
   padding: 0.75rem;
   border: none;
   border-radius: 6px;


### PR DESCRIPTION
## Summary
- center modal action buttons globally and in professor screens

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a76bb667b0832ba4766762314e3f50