### PR TITLE
Fix class request status flow

### DIFF
--- a/src/screens/alumno/acciones/Clases.jsx
+++ b/src/screens/alumno/acciones/Clases.jsx
@@ -507,9 +507,14 @@ export default function Clases() {
               </Card>
             ))}
             {solicitudes.map(s => {
-              const estado = s.estado === 'pendiente'
-                ? (s.offers === 0 ? 'En búsqueda de profesor' : 'En selección de profesor')
-                : 'Profesor asignado';
+              let estado;
+              if (s.estado === 'pendiente') {
+                estado = s.offers === 0 ? 'En búsqueda de profesor' : 'En selección de profesor';
+              } else if (s.estado === 'en_proceso') {
+                estado = 'Esperando respuesta del profesor';
+              } else {
+                estado = 'Profesor asignado';
+              }
               return (
                 <Card key={s.id}>
                   <InfoGrid>

--- a/src/screens/alumno/acciones/NuevaClase.jsx
+++ b/src/screens/alumno/acciones/NuevaClase.jsx
@@ -492,7 +492,7 @@ export default function NuevaClase() {
         fecha_inicio: startDate,
         fecha_fin: endDate,
         disponibilidad: Array.from(selectedSlots).join(','),
-        estado: 'En búsqueda de profesor',
+        estado: 'pendiente',
         numero_horas: parseInt(horasSemana, 10),
         modalidad,
         tipo: tipoClase,
@@ -527,7 +527,7 @@ export default function NuevaClase() {
         precioPadres,
         precioProfesores,
         notas,
-        estado: 'En búsqueda de profesor',
+        estado: 'pendiente',
         ofertaId: ofertaRes.id,
         createdAt: serverTimestamp()
       });


### PR DESCRIPTION
## Summary
- Ensure new class requests use `pendiente` state internally
- Show proper status texts for class requests, including waiting for teacher response

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68a76ead7598832b9ba02261236d087e