### PR TITLE
Format class modality values and streamline presencial requests

### DIFF
--- a/src/screens/alumno/acciones/NuevaClase.jsx
+++ b/src/screens/alumno/acciones/NuevaClase.jsx
@@ -244,7 +244,6 @@ export default function NuevaClase() {
   const [modalidad, setModalidad]         = useState('online');
   const [ciudad, setCiudad]               = useState('');
   const [cityGroups, setCityGroups]       = useState({});
-  const [zona, setZona]                   = useState('');
   const [startDate, setStartDate]         = useState(getToday());
   const [endDate, setEndDate]             = useState('');
   const [noEndDate, setNoEndDate]         = useState(false);
@@ -487,6 +486,7 @@ export default function NuevaClase() {
     if (submitting) return;
     setSubmitting(true);
     try {
+      const modalidadStore = modalidad === 'presencial' ? 'Presencial' : 'Online';
       const ofertaRes = await createOferta({
         fecha_oferta: new Date().toISOString().slice(0,10),
         fecha_inicio: startDate,
@@ -494,7 +494,7 @@ export default function NuevaClase() {
         disponibilidad: Array.from(selectedSlots).join(','),
         estado: 'pendiente',
         numero_horas: parseInt(horasSemana, 10),
-        modalidad,
+        modalidad: modalidadStore,
         tipo: tipoClase,
         beneficio_sp: precioPadres - precioProfesores,
         ganancia_profesor: precioProfesores,
@@ -517,9 +517,8 @@ export default function NuevaClase() {
         asignaturas,
         curso,
         tipoClase,
-        modalidad,
+        modalidad: modalidadStore,
         ciudad,
-        zona: modalidad === 'presencial' ? zona : null,
         fechaInicio: startDate,
         fechaFin: endDate,
         horasSemana: parseInt(horasSemana, 10),
@@ -665,7 +664,10 @@ export default function NuevaClase() {
                   name="modalidad"
                   value="presencial"
                   checked={modalidad === 'presencial'}
-                  onChange={e => setModalidad(e.target.value)}
+                  onChange={e => {
+                    setModalidad(e.target.value);
+                    alert('Si se elige presencial, la dirección usada será la del alumno');
+                  }}
                 /> Presencial
               </label>
             </div>
@@ -693,17 +695,7 @@ export default function NuevaClase() {
             </DropdownContainer>
           </Field>
 
-          {/* Zona / Barrio */}
-          {modalidad === 'presencial' && (
-            <Field>
-              <label>Zona / Barrio</label>
-              <input className="form-control"
-                value={zona}
-                onChange={e => setZona(e.target.value)}
-                placeholder="Centro, Norte..."
-              />
-            </Field>
-          )}
+          {/* Zona / Barrio eliminado para modalidad presencial */}
 
           {/* Fecha de inicio y fecha de fin por día */}
           <Field ref={datesRef} error={errors.fechas} style={{ gridColumn: '1 / -1' }}>

--- a/src/screens/profesor/acciones/MisAlumnos.jsx
+++ b/src/screens/profesor/acciones/MisAlumnos.jsx
@@ -460,6 +460,7 @@ export default function MisAlumnos() {
     const precioPad = parseFloat(data.precioPadres || 0);
 
     // Guardamos la propuesta en subcolección 'clases_asignadas'
+    const modalidadStore = modalidad === 'presencial' ? 'Presencial' : 'Online';
     await addDoc(
       collection(db, 'clases_union', selectedUnion.id, 'clases_asignadas'),
       {
@@ -468,7 +469,7 @@ export default function MisAlumnos() {
         fecha: fechaClase,
         duracion: durNum,
         asignatura: asignMateria,
-        modalidad,
+        modalidad: modalidadStore,
         precioProfesor: precioProf,
         precioPadres: precioPad,
         precioTotalProfesor: +(precioProf * durNum).toFixed(2),

--- a/src/screens/profesor/acciones/Ofertas.jsx
+++ b/src/screens/profesor/acciones/Ofertas.jsx
@@ -624,7 +624,7 @@ export default function Ofertas() {
     const matchAsign = filterAsignatura
       ? (c.asignaturas ? c.asignaturas.includes(filterAsignatura) : c.asignatura === filterAsignatura)
       : true;
-    const matchModalidad = filterModalidad ? c.modalidad === filterModalidad : true;
+    const matchModalidad = filterModalidad ? (c.modalidad || '').toLowerCase() === filterModalidad.toLowerCase() : true;
     const matchTipo = filterTipoClase ? c.tipoClase === filterTipoClase : true;
     const matchCurso = filterCurso ? c.curso === filterCurso : true;
     return matchAsign && matchModalidad && matchTipo && matchCurso;
@@ -716,12 +716,12 @@ export default function Ofertas() {
                       Todas
                     </DropdownItem>
                     <DropdownItem
-                      onClick={() => { setFilterModalidad('online'); setOpenModalidadFiltro(false); }}
+                      onClick={() => { setFilterModalidad('Online'); setOpenModalidadFiltro(false); }}
                     >
                       Online
                     </DropdownItem>
                     <DropdownItem
-                      onClick={() => { setFilterModalidad('presencial'); setOpenModalidadFiltro(false); }}
+                      onClick={() => { setFilterModalidad('Presencial'); setOpenModalidadFiltro(false); }}
                     >
                       Presencial
                     </DropdownItem>
@@ -799,7 +799,7 @@ export default function Ofertas() {
                   <Label>Modalidad:</Label>{' '}
                   <Value>{c.modalidad.charAt(0).toUpperCase() + c.modalidad.slice(1)}</Value>
                 </div>
-                {c.modalidad === 'presencial' && (
+                {c.modalidad && c.modalidad.toLowerCase() === 'presencial' && (
                   <div>
                     <Label>Zona:</Label>{' '}
                     <Value>{c.zona || '—'}</Value>


### PR DESCRIPTION
## Summary
- Store class modality as `Online` or `Presencial` and drop zone input for presencial requests
- Warn users that presencial classes use the student's address
- Adjust filters and teacher proposals to work with capitalized modalities

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68a77179589c832bb9e66e006d3b8b52