### PR TITLE
fix: remove undefined setZona reference

### DIFF
--- a/src/screens/alumno/acciones/NuevaClase.jsx
+++ b/src/screens/alumno/acciones/NuevaClase.jsx
@@ -470,7 +470,6 @@ export default function NuevaClase() {
     setTipoClase('individual');
     setModalidad('online');
     setCiudad('');
-    setZona('');
     setStartDate(getToday());
     setEndDate('');
     setNoEndDate(false);


### PR DESCRIPTION
## Summary
- remove leftover setZona call from form reset

## Testing
- `CI=true npm test -- --passWithNoTests`
- `npx eslint src/screens/alumno/acciones/NuevaClase.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68a774c6f45c832bb00371545948c99c