### PR TITLE
Add progress tracking bars for pending classes

### DIFF
--- a/src/components/ProgressBar.jsx
+++ b/src/components/ProgressBar.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const BarContainer = styled.div`
+  width: 100%;
+  background: #e2e8f0;
+  border-radius: 8px;
+  overflow: hidden;
+  height: 8px;
+  margin: 0.75rem 0;
+`;
+
+const Bar = styled.div`
+  height: 100%;
+  width: ${p => p.percent}%;
+  background: ${p => p.color};
+  transition: width 0.3s ease;
+`;
+
+export default function ProgressBar({ percent, color }) {
+  return (
+    <BarContainer>
+      <Bar percent={percent} color={color} />
+    </BarContainer>
+  );
+}

--- a/src/screens/alumno/acciones/Clases.jsx
+++ b/src/screens/alumno/acciones/Clases.jsx
@@ -5,6 +5,7 @@ import { useSearchParams, Link } from 'react-router-dom';
 import { useChild } from '../../../ChildContext';
 import Card from '../../../components/CommonCard';
 import InfoGrid from '../../../components/InfoGrid';
+import ProgressBar from '../../../components/ProgressBar';
 import Tabs from "../../../components/Tabs";
 import { auth, db } from '../../../firebase/firebaseConfig';
 import {
@@ -131,6 +132,18 @@ const RejectButton = styled.button`
     cursor: not-allowed;
   }
 `;
+
+const getProgressData = s => {
+  if (s.estado === 'pendiente') {
+    return s.offers === 0
+      ? { percent: 25, color: '#e53e3e', label: 'En búsqueda de profesor' }
+      : { percent: 50, color: '#dd6b20', label: 'En selección de profesor' };
+  }
+  if (s.estado === 'en_proceso') {
+    return { percent: 75, color: '#3182ce', label: 'Esperando respuesta del profesor' };
+  }
+  return { percent: 100, color: '#38a169', label: 'Profesor asignado' };
+};
 
 export default function Clases() {
   const { selectedChild } = useChild();
@@ -507,14 +520,7 @@ export default function Clases() {
               </Card>
             ))}
             {solicitudes.map(s => {
-              let estado;
-              if (s.estado === 'pendiente') {
-                estado = s.offers === 0 ? 'En búsqueda de profesor' : 'En selección de profesor';
-              } else if (s.estado === 'en_proceso') {
-                estado = 'Esperando respuesta del profesor';
-              } else {
-                estado = 'Profesor asignado';
-              }
+              const { percent, color, label } = getProgressData(s);
               return (
                 <Card key={s.id}>
                   <InfoGrid>
@@ -534,12 +540,15 @@ export default function Clases() {
                       <Label>Horas/semana:</Label> <Value>{s.horasSemana}</Value>
                     </div>
                     <div>
-                      <Label>Estado:</Label> <Value>{estado}</Value>
+                      <Label>Estado:</Label> <Value>{label}</Value>
                     </div>
                   </InfoGrid>
+                  {label !== 'Profesor asignado' && (
+                    <ProgressBar percent={percent} color={color} />
+                  )}
                 </Card>
               );
-              })}
+            })}
               </>
             )
           )}

--- a/src/screens/profesor/acciones/Ofertas.jsx
+++ b/src/screens/profesor/acciones/Ofertas.jsx
@@ -4,6 +4,7 @@ import styled, { keyframes } from 'styled-components';
 import { useNotification } from '../../../NotificationContext';
 import { auth, db } from '../../../firebase/firebaseConfig';
 import InfoGrid from '../../../components/InfoGrid';
+import ProgressBar from '../../../components/ProgressBar';
 import { useAuth } from '../../../AuthContext';
 import CompleteTeacherProfileModal from '../../../components/CompleteTeacherProfileModal';
 import {
@@ -358,6 +359,12 @@ const SlotCell = styled.div`
   transition: background 0.2s, border 0.2s;
 `;
 
+const getProgressData = c => {
+  return c.offers === 0
+    ? { percent: 25, color: '#e53e3e' }
+    : { percent: 50, color: '#dd6b20' };
+};
+
 export default function Ofertas() {
   // Datos de perfil y clases
   const { userData } = useAuth();
@@ -410,12 +417,10 @@ export default function Ofertas() {
       const disponibles = [];
       for (const d of snap2.docs) {
         const data = d.data();
-        const offersSnap = await getDocs(
-          query(collection(db, 'clases', d.id, 'ofertas'),
-                where('profesorId', '==', u.uid))
-        );
-        if (offersSnap.empty) {
-          disponibles.push({ id: d.id, ...data });
+        const offersSnap = await getDocs(collection(db, 'clases', d.id, 'ofertas'));
+        const hasOffer = offersSnap.docs.some(docu => docu.data().profesorId === u.uid);
+        if (!hasOffer) {
+          disponibles.push({ id: d.id, offers: offersSnap.size, ...data });
         }
       }
       setClases(disponibles);
@@ -842,6 +847,10 @@ export default function Ofertas() {
                 </SubjectChip>
               ))}
             </div>
+
+            {c.estado === 'pendiente' && (
+              <ProgressBar {...getProgressData(c)} />
+            )}
 
               <Controls>
                 <ShowScheduleText onClick={() => toggleExpand(c.id)}>


### PR DESCRIPTION
## Summary
- show progress bar on student requests to visualize tutor matching stages
- display progress bar in teacher offers with color cues based on offers count
- create reusable ProgressBar component

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a7757c8a60832ba062a17bb6404815