### PR TITLE
feat: notify tutor and store accepted classes

### DIFF
--- a/node-server/README.md
+++ b/node-server/README.md
@@ -88,6 +88,47 @@ Envía un `POST` a `http://localhost:3001/send-assignment-email` con un cuerpo c
 El campo `recipient` puede ser `teacher`, `student` o `both` para indicar a quién se envía la notificación.
 Se utilizará para avisar al profesor cuando la administración lo seleccione y al alumno cuando el profesor acepte la solicitud.
 
+### Notificar clase al tutor
+
+Permite avisar al tutor cuando el profesor propone una clase para su alumno:
+
+```bash
+POST http://localhost:3001/notify-tutor-class
+{
+  "tutorEmail": "tutor@ejemplo.com",
+  "tutorName": "Nombre Tutor",
+  "teacherName": "Nombre Profesor",
+  "studentName": "Nombre Alumno",
+  "classDate": "2024-01-01",
+  "classTime": "17:00"
+}
+```
+
+Se enviará un correo al tutor indicando la fecha y hora de la clase para que la confirme entrando en el chat con el profesor.
+
+### Registrar aceptación de clase
+
+Cuando el tutor confirma la clase se debe registrar en la base de datos:
+
+```bash
+POST http://localhost:3001/accept-class
+{
+  "fecha_clase": "2024-01-01",
+  "hora_clase": "17:00",
+  "modalidad_clase": "Online",
+  "precio_total_clase": 0,
+  "beneficio_clase": 0,
+  "duracion_clase": 1,
+  "fecha_registro_clase": "2024-01-01",
+  "id_asignatura": 1,
+  "id_ubicacion": 1,
+  "id_profesor": 1,
+  "id_alumno": 1
+}
+```
+
+El servidor insertará estos datos en la tabla `student_project.clase`.
+
 ### Sincronización con Google Sheets
 
 Para registrar usuarios y clases en una hoja de cálculo debes especificar

--- a/node-server/index.js
+++ b/node-server/index.js
@@ -680,6 +680,85 @@ app.post('/send-assignment-email', async (req, res) => {
   }
 });
 
+app.post('/notify-tutor-class', async (req, res) => {
+  const {
+    tutorEmail,
+    tutorName,
+    teacherName,
+    studentName,
+    classDate,
+    classTime,
+  } = req.body;
+
+  if (!tutorEmail) {
+    return res.status(400).json({ error: 'Falta correo del tutor' });
+  }
+
+  const html = `
+      <p>Hola ${tutorName || 'tutor'}, el profesor ${teacherName || 'profesor'} ha añadido una clase para el alumno ${studentName || ''}.</p>
+      <p>Fecha y hora: ${classDate || ''} a las ${classTime || ''}.</p>
+      <p>Por favor, entra en el chat con el profesor para aceptarla.</p>
+    `;
+
+  try {
+    await transporter.sendMail({
+      from: `"Student Project" <${process.env.EMAIL_USER || 'alvaro@studentproject.es'}>`,
+      to: tutorEmail,
+      subject: 'Nueva clase pendiente de confirmar',
+      html,
+    });
+    res.json({ message: 'Correo enviado al tutor' });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Error enviando correo' });
+  }
+});
+
+app.post('/accept-class', async (req, res) => {
+  const {
+    fecha_clase,
+    hora_clase,
+    modalidad_clase,
+    precio_total_clase,
+    beneficio_clase,
+    duracion_clase,
+    fecha_registro_clase,
+    id_asignatura,
+    id_ubicacion,
+    id_profesor,
+    id_alumno,
+  } = req.body;
+
+  let client;
+  try {
+    client = await db.connect();
+    await client.query(
+      `INSERT INTO student_project.clase
+        (fecha_clase, hora_clase, modalidad_clase, precio_total_clase, beneficio_clase, duracion_clase, fecha_registro_clase, id_asignatura, id_ubicacion, id_profesor, id_alumno)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+      [
+        fecha_clase,
+        hora_clase,
+        modalidad_clase,
+        precio_total_clase,
+        beneficio_clase,
+        duracion_clase,
+        fecha_registro_clase,
+        id_asignatura,
+        id_ubicacion,
+        id_profesor,
+        id_alumno,
+      ]
+    );
+    res.json({ message: 'Clase aceptada' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Error registrando la clase' });
+  } finally {
+    if (client) client.release();
+  }
+});
+
 app.post('/request-password-reset', async (req, res) => {
   const { email } = req.body;
   if (!email) return res.status(400).json({ error: 'Email requerido' });


### PR DESCRIPTION
## Summary
- send email to tutor when a professor schedules a class
- add endpoint to persist accepted classes in Postgres
- document new endpoints in node server

## Testing
- `npm test -- --watchAll=false`
- `node --check node-server/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68a874a99578832bb6ae6ce0fe38888c