### PR TITLE
Add payments tracking and admin payments view

### DIFF
--- a/bbdd/sp_bbdd.sql
+++ b/bbdd/sp_bbdd.sql
@@ -369,3 +369,15 @@ INSERT INTO student_project.ciudad (nombre, id_grupo) VALUES
     ('Malaga',    (SELECT id_grupo FROM student_project.grupo WHERE nombre = 'B')),
     ('Valencia',  (SELECT id_grupo FROM student_project.grupo WHERE nombre = 'B'))
 ON CONFLICT (nombre) DO NOTHING;
+-- -----------------------------------------------------
+-- Table `student_project`.`saldo_usuario`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS student_project.saldo_usuario (
+    user_id VARCHAR(100) NOT NULL,
+    rol VARCHAR(20) NOT NULL,
+    saldo numeric NOT NULL DEFAULT 0,
+    PRIMARY KEY (user_id, rol)
+);
+
+COMMENT ON TABLE student_project.saldo_usuario
+    IS 'Saldo acumulado por usuario para pagos a liquidar.';

--- a/src/screens/admin/PanelAdmin.jsx
+++ b/src/screens/admin/PanelAdmin.jsx
@@ -10,9 +10,11 @@ import {
 import { db } from '../../firebase/firebaseConfig';
 
 // Importa tu componente de gestión de clases para admin
+
 import GestionClases from './acciones/GestionClases';
 import Facturacion   from './acciones/Facturacion';
 import Usuarios      from './acciones/Usuarios';
+import Pagos        from './acciones/Pagos';
 
 const Container = styled.div`
   display: flex;
@@ -219,6 +221,8 @@ export default function PanelAdmin() {
         return <GestionClases />;
       case 'facturacion':
         return <Facturacion />;
+      case 'pagos':
+        return <Pagos />;
       case 'usuarios':
         return <Usuarios />;
       default:
@@ -245,6 +249,14 @@ export default function PanelAdmin() {
               onClick={() => setView('facturacion')}
             >
               Facturación
+            </Button>
+          </MenuItem>
+          <MenuItem>
+            <Button
+              active={view === 'pagos'}
+              onClick={() => setView('pagos')}
+            >
+              Pagos
             </Button>
           </MenuItem>
           <MenuItem>

--- a/src/screens/admin/acciones/Pagos.jsx
+++ b/src/screens/admin/acciones/Pagos.jsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { fetchBalances, liquidarBalance } from '../../../utils/api';
+
+const Container = styled.div`
+  max-width: 900px;
+  margin: 0 auto;
+`;
+
+const Switch = styled.div`
+  margin-bottom: 1rem;
+  button {
+    margin-right: 0.5rem;
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+`;
+
+const Table = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  th, td {
+    border: 1px solid #ccc;
+    padding: 0.5rem;
+    text-align: left;
+  }
+`;
+
+export default function Pagos() {
+  const [role, setRole] = useState('tutor');
+  const [rows, setRows] = useState([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await fetchBalances(role);
+        setRows(data);
+      } catch (e) {
+        console.error(e);
+      }
+    })();
+  }, [role]);
+
+  const handleLiquidar = async id => {
+    try {
+      const email = role === 'tutor' ? id : undefined;
+      await liquidarBalance(id, role, email);
+      setRows(r => r.map(x => x.user_id === id ? { ...x, saldo: 0 } : x));
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <Container>
+      <h2>Pagos</h2>
+      <Switch>
+        <button disabled={role==='tutor'} onClick={() => setRole('tutor')}>Tutores</button>
+        <button disabled={role==='profesor'} onClick={() => setRole('profesor')}>Profesores</button>
+      </Switch>
+      <Table>
+        <thead>
+          <tr><th>Usuario</th><th>Saldo (€)</th><th></th></tr>
+        </thead>
+        <tbody>
+          {rows.map(r => (
+            <tr key={r.user_id}>
+              <td>{r.user_id}</td>
+              <td>{r.saldo}</td>
+              <td><button onClick={() => handleLiquidar(r.user_id)}>Liquidar</button></td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </Container>
+  );
+}

--- a/src/screens/alumno/acciones/Clases.jsx
+++ b/src/screens/alumno/acciones/Clases.jsx
@@ -21,6 +21,7 @@ import {
   onSnapshot
 } from 'firebase/firestore';
 import { acceptClassByStudent, rejectPendingClass } from '../../../utils/classWorkflow';
+import { registerTransaction } from "../../../utils/api";
 
 const fadeIn = keyframes`
   from { opacity: 0; transform: translateY(-10px); }
@@ -266,6 +267,12 @@ export default function Clases() {
         senderId: clase.profesorId,
         text: `He añadido una clase, ${clase.fecha}`,
         createdAt: serverTimestamp()
+      });
+      await registerTransaction({
+        alumnoId: auth.currentUser.uid,
+        profesorId: clase.profesorId,
+        montoTutor: clase.precioTotalPadres,
+        montoProfesor: clase.precioTotalProfesor,
       });
       setClases(prev => prev.map(c =>
         c.id === clase.id ? { ...c, estado: 'aceptada', confirmada: true } : c

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -94,3 +94,26 @@ export async function confirmPuja(id) {
   const res = await fetch(`${API_URL}/puja/${id}/confirm`, { method: 'POST' });
   return handleResponse(res);
 }
+
+export async function registerTransaction(data) {
+  const res = await fetch(`${API_URL}/transaccion`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  return handleResponse(res);
+}
+
+export async function fetchBalances(role) {
+  const res = await fetch(`${API_URL}/balances?role=${role}`);
+  return handleResponse(res);
+}
+
+export async function liquidarBalance(userId, role, email) {
+  const res = await fetch(`${API_URL}/balances/${userId}/liquidar`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ role, email }),
+  });
+  return handleResponse(res);
+}


### PR DESCRIPTION
## Summary
- track balances under tutors instead of individual students
- update admin Pagos view and transaction flow to handle tutor balances

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a882e69acc832bb3e3c0d32d07a0e6