### PR TITLE
Make student phone optional in tutor registration

### DIFF
--- a/node-server/index.js
+++ b/node-server/index.js
@@ -231,7 +231,14 @@ app.post('/tutor', async (req, res) => {
       ]
     );
 
-    if (alumno.telefono !== alumno.telefonoConfirm) {
+    const telefonoAlumno = alumno.telefono && alumno.telefono.trim() !== ''
+      ? alumno.telefono
+      : tutor.telefono;
+    if (
+      alumno.telefono &&
+      alumno.telefonoConfirm &&
+      alumno.telefono !== alumno.telefonoConfirm
+    ) {
       throw new Error('Teléfonos no coinciden');
     }
 
@@ -265,7 +272,7 @@ app.post('/tutor', async (req, res) => {
         alumno.apellidos,
         alumno.direccion,
         alumno.NIF,
-        alumno.telefono,
+        telefonoAlumno,
         alumno.genero,
         tutor.correo_electronico,
         alumno.id_curso,
@@ -290,9 +297,21 @@ app.post('/alumno', async (req, res) => {
   try {
     client = await db.connect();
     await client.query('BEGIN');
-
-    if (alumno.telefono !== alumno.telefonoConfirm) {
+    if (
+      alumno.telefono &&
+      alumno.telefonoConfirm &&
+      alumno.telefono !== alumno.telefonoConfirm
+    ) {
       throw new Error('Teléfonos no coinciden');
+    }
+
+    let telefonoAlumno = alumno.telefono && alumno.telefono.trim() !== '' ? alumno.telefono : null;
+    if (!telefonoAlumno) {
+      const tutorRes = await client.query(
+        'SELECT telefono FROM student_project.tutor WHERE correo_electronico=$1',
+        [tutor_email]
+      );
+      telefonoAlumno = tutorRes.rows[0]?.telefono || null;
     }
 
     const cityRes = await client.query(
@@ -325,7 +344,7 @@ app.post('/alumno', async (req, res) => {
         alumno.apellidos,
         alumno.direccion,
         alumno.NIF,
-        alumno.telefono,
+        telefonoAlumno,
         alumno.genero,
         tutor_email,
         alumno.id_curso,

--- a/src/components/AddChildModal.jsx
+++ b/src/components/AddChildModal.jsx
@@ -54,48 +54,48 @@ export default function AddChildModal({ open, onClose }) {
     if (
       !name ||
       !lastName ||
-      !gender ||
-      !courseId ||
-      !phone ||
-      phone !== phoneConfirm ||
-      !nif ||
-      !address ||
-      !district ||
-      !city ||
-      saving
-    ) return;
+        !gender ||
+        !courseId ||
+        (phone && phone !== phoneConfirm) ||
+        !nif ||
+        !address ||
+        !district ||
+        !city ||
+        saving
+      ) return;
     setSaving(true);
     try {
-      await registerAlumno({
-        tutor_email: userData?.email || auth.currentUser.email,
-        alumno: {
-          nombre: name,
-          apellidos: lastName,
-          direccion: address,
-          NIF: nif,
-          telefono: phone,
-          telefonoConfirm: phoneConfirm,
-          genero: gender,
-          id_curso: courseId,
-          distrito: district,
-          ciudad: city,
-        }
-      });
+        await registerAlumno({
+          tutor_email: userData?.email || auth.currentUser.email,
+          alumno: {
+            nombre: name,
+            apellidos: lastName,
+            direccion: address,
+            NIF: nif,
+            telefono: phone || null,
+            telefonoConfirm: phoneConfirm || null,
+            genero: gender,
+            id_curso: courseId,
+            distrito: district,
+            ciudad: city,
+          }
+        });
 
         const courseName = courses.find(c => c.id_curso === parseInt(courseId))?.nombre || '';
-      const nuevo = {
-        id: Date.now().toString(),
-        nombre: name,
-        apellidos: lastName,
-        genero: gender,
-        curso: courseName,
-        telefono: phone,
-        NIF: nif,
-        direccion: address,
-        distrito: district,
-        ciudad: city,
-        photoURL: userData?.photoURL || auth.currentUser.photoURL || ''
-      };
+        const finalPhone = phone || userData?.telefono || '';
+        const nuevo = {
+          id: Date.now().toString(),
+          nombre: name,
+          apellidos: lastName,
+          genero: gender,
+          curso: courseName,
+          telefono: finalPhone,
+          NIF: nif,
+          direccion: address,
+          distrito: district,
+          ciudad: city,
+          photoURL: userData?.photoURL || auth.currentUser.photoURL || ''
+        };
       const nuevos = [...childList, nuevo];
       await updateDoc(doc(db, 'usuarios', auth.currentUser.uid), { alumnos: nuevos });
       setChildList(nuevos.filter(c => !c.disabled));

--- a/src/screens/SignUpTutor.jsx
+++ b/src/screens/SignUpTutor.jsx
@@ -371,8 +371,7 @@ export default function SignUpTutor() {
     if (!barrioTutor) missing.push('Barrio, Localidad, Distrito...');
     if (!codigoPostalTutor) missing.push('Código postal facturación');
     if (!nifAlumno) missing.push('NIF del Alumno');
-    if (!telefonoHijo) missing.push('Teléfono del Alumno');
-    if (!confirmTelefonoHijo) missing.push('Repitir Teléfono');
+    if (telefonoHijo && !confirmTelefonoHijo) missing.push('Repitir Teléfono del Alumno');
     if (!direccionAlumno) missing.push('Dirección lugar clase');
     if (!distritoAlumno) missing.push('Barrio, Localidad, Distrito...');
     if (!nombreHijo) missing.push('Nombre del Alumno');
@@ -391,7 +390,7 @@ export default function SignUpTutor() {
       setTelefonoError('Los números no coinciden');
       return;
     }
-    if (telefonoHijo !== confirmTelefonoHijo) {
+    if (telefonoHijo && telefonoHijo !== confirmTelefonoHijo) {
       setTelefonoHijoError('Los números no coinciden');
       return;
     }
@@ -434,7 +433,7 @@ export default function SignUpTutor() {
             apellidos: apellidoHijo,
             genero: generoHijo,
             curso,
-            telefono: telefonoHijo,
+            telefono: telefonoHijo || telefono,
             NIF: nifAlumno,
             direccion: direccionAlumno,
             distrito: distritoAlumno,
@@ -466,8 +465,8 @@ export default function SignUpTutor() {
           distrito: distritoAlumno,
           ciudad,
           NIF: nifAlumno,
-          telefono: telefonoHijo,
-          telefonoConfirm: confirmTelefonoHijo,
+          telefono: telefonoHijo || null,
+          telefonoConfirm: confirmTelefonoHijo || null,
           genero: generoHijo,
           id_curso: idCurso,
         }

--- a/src/screens/alumno/acciones/MisAlumnos.jsx
+++ b/src/screens/alumno/acciones/MisAlumnos.jsx
@@ -96,52 +96,52 @@ export default function MisAlumnos() {
       !lastName ||
       !gender ||
       !date ||
-      !courseId ||
-      !phone ||
-      phone !== phoneConfirm ||
-      !nif ||
-      !address ||
-      !district ||
-      !city ||
-      saving
-    ) return;
+        !courseId ||
+        (phone && phone !== phoneConfirm) ||
+        !nif ||
+        !address ||
+        !district ||
+        !city ||
+        saving
+      ) return;
     setSaving(true);
     try {
-      await registerAlumno({
-        tutor_email: userData?.email || auth.currentUser.email,
-        alumno: {
+        await registerAlumno({
+          tutor_email: userData?.email || auth.currentUser.email,
+          alumno: {
+            nombre: name,
+            apellidos: lastName,
+            direccion: address,
+            NIF: nif,
+            telefono: phone || null,
+            telefonoConfirm: phoneConfirm || null,
+            genero: gender,
+            id_curso: courseId,
+            distrito: district,
+            barrio,
+            codigo_postal: postalCode,
+            ciudad: city,
+          }
+        });
+
+      const courseName = courses.find(c => c.id_curso === parseInt(courseId))?.curso || '';
+        const finalPhone = phone || userData?.telefono || '';
+        const nuevo = {
+          id: Date.now().toString(),
           nombre: name,
           apellidos: lastName,
-          direccion: address,
-          NIF: nif,
-          telefono: phone,
-          telefonoConfirm: phoneConfirm,
           genero: gender,
-          id_curso: courseId,
+          fechaNacimiento: date,
+          curso: courseName,
+          telefono: finalPhone,
+          NIF: nif,
+          direccion: address,
           distrito: district,
           barrio,
           codigo_postal: postalCode,
           ciudad: city,
-        }
-      });
-
-      const courseName = courses.find(c => c.id_curso === parseInt(courseId))?.curso || '';
-      const nuevo = {
-        id: Date.now().toString(),
-        nombre: name,
-        apellidos: lastName,
-        genero: gender,
-        fechaNacimiento: date,
-        curso: courseName,
-        telefono: phone,
-        NIF: nif,
-        direccion: address,
-        distrito: district,
-        barrio,
-        codigo_postal: postalCode,
-        ciudad: city,
-        photoURL: userData?.photoURL || auth.currentUser.photoURL || ''
-      };
+          photoURL: userData?.photoURL || auth.currentUser.photoURL || ''
+        };
       const nuevos = [...childList, nuevo];
       await updateDoc(doc(db, 'usuarios', auth.currentUser.uid), { alumnos: nuevos });
       setChildList(nuevos.filter(c => !c.disabled));


### PR DESCRIPTION
## Summary
- Allow omitting student phone when registering tutor or adding students
- Default to tutor's phone when student phone absent
- Persist optional phone correctly in PostgreSQL and Firestore

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a8aa00da88832b8b1ff79c71e7bac1