### PR TITLE
feat: defer teacher banking and academic info

### DIFF
--- a/node-server/index.js
+++ b/node-server/index.js
@@ -391,6 +391,21 @@ app.post('/profesor', async (req, res) => {
   }
 });
 
+app.put('/profesor', async (req, res) => {
+  const { correo_electronico, NIF = null, IBAN = null, carrera = null, curso = null, experiencia = null } = req.body;
+  if (!correo_electronico) return res.status(400).json({ error: 'Falta correo del profesor' });
+  try {
+    await db.query(
+      'UPDATE student_project.profesor SET "NIF"=$1, "IBAN"=$2, carrera=$3, curso=$4, experiencia=$5 WHERE correo_electronico=$6',
+      [NIF, IBAN, carrera, curso, experiencia, correo_electronico]
+    );
+    res.json({ message: 'Profesor actualizado' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Error actualizando profesor' });
+  }
+});
+
 app.post('/oferta', async (req, res) => {
   const {
     fecha_oferta,

--- a/src/components/CompleteTeacherProfileModal.jsx
+++ b/src/components/CompleteTeacherProfileModal.jsx
@@ -4,6 +4,7 @@ import { TextInput, SelectInput, PrimaryButton } from './FormElements';
 import { auth, db } from '../firebase/firebaseConfig';
 import { doc, updateDoc } from 'firebase/firestore';
 import { useAuth } from '../AuthContext';
+import { updateProfesor } from '../utils/api';
 import { Overlay, Modal, ModalTitle } from './ModalStyles';
 
 const DNI_LETTERS = 'TRWAGMYFPDXBNJZSQVHLCKE';
@@ -68,6 +69,7 @@ export default function CompleteTeacherProfileModal({ open, onClose, userData })
   const [studyTime, setStudyTime] = useState(userData?.studyTime || '');
   const [finished, setFinished] = useState(userData?.careerFinished || false);
   const [iban, setIban] = useState(userData?.iban || '');
+  const [experience, setExperience] = useState(userData?.experiencia || '');
   const [saving, setSaving] = useState(false);
   const [dniError, setDniError] = useState('');
   const [ibanError, setIbanError] = useState('');
@@ -98,7 +100,7 @@ export default function CompleteTeacherProfileModal({ open, onClose, userData })
 
   const save = async () => {
     const finalDocType = docSelect === 'DNI' ? 'DNI' : docTypeOther.trim();
-    if (!finalDocType || !docNumber || !studies || !iban) return;
+    if (!finalDocType || !docNumber || !studies || (!finished && !studyTime) || !experience || !iban) return;
     if (docSelect === 'DNI' && dniError) return;
     if (ibanError) return;
     if (saving) return;
@@ -111,6 +113,19 @@ export default function CompleteTeacherProfileModal({ open, onClose, userData })
       careerFinished: finished,
       status: 'estudia',
       iban,
+      NIF: docNumber,
+      IBAN: iban,
+      carrera: studies,
+      curso: studyTime,
+      experiencia: Number(experience),
+    });
+    await updateProfesor({
+      correo_electronico: auth.currentUser.email,
+      NIF: docNumber,
+      IBAN: iban,
+      carrera: studies,
+      curso: studyTime,
+      experiencia: Number(experience),
     });
     await refreshUserData();
     setSaving(false);
@@ -180,6 +195,14 @@ export default function CompleteTeacherProfileModal({ open, onClose, userData })
               onChange={e => setFinished(e.target.checked)}
             />{' '}Carrera finalizada
           </label>
+        </Field>
+        <Field>
+          <label>Años de experiencia</label>
+          <TextInput
+            type="number"
+            value={experience}
+            onChange={e => setExperience(e.target.value)}
+          />
         </Field>
         <Field>
           <label>IBAN o número de cuenta</label>

--- a/src/screens/SignUpProfesor.jsx
+++ b/src/screens/SignUpProfesor.jsx
@@ -267,8 +267,7 @@ export default function SignUpProfesor() {
   const [distrito, setDistrito] = useState('');
   const [barrio, setBarrio] = useState('');
   const [codigoPostal, setCodigoPostal] = useState('');
-  const [curso, setCurso] = useState('');
-  const [experiencia, setExperiencia] = useState('');
+  // Datos acad\u00e9micos y bancarios se recopilar\u00e1n m\u00e1s adelante.
   const navigate = useNavigate();
   const { show } = useNotification();
   const ref = useRef();
@@ -345,8 +344,6 @@ export default function SignUpProfesor() {
     if (!distrito) missing.push('Distrito');
     if (!barrio) missing.push('Barrio');
     if (!codigoPostal) missing.push('Código Postal');
-    if (!curso) missing.push('Curso');
-    if (experiencia === '') missing.push('Años de experiencia');
     if (!emailVerified) missing.push('Verificación de correo');
     if (missing.length) {
       show('Faltan: ' + missing.join(', '), 'error');
@@ -392,8 +389,8 @@ export default function SignUpProfesor() {
         codigo_postal: codigoPostal,
         IBAN: null,
         carrera: null,
-        curso,
-        experiencia: Number(experiencia),
+        curso: null,
+        experiencia: null,
       });
       const genero = salutation === 'Sr.' ? 'Masculino' : 'Femenino';
       await registerProfesor({
@@ -410,8 +407,8 @@ export default function SignUpProfesor() {
         ciudad,
         IBAN: null,
         carrera: null,
-        curso,
-        experiencia: Number(experiencia),
+        curso: null,
+        experiencia: null,
         password,
       });
       await sendWelcomeEmail({ email, name: nombre });
@@ -612,30 +609,7 @@ export default function SignUpProfesor() {
                   <label className="fl-label">Código Postal</label>
                 </div>
               </Field>
-              <Field>
-                <div className="fl-field">
-                  <input
-                    className="form-control fl-input"
-                    type="text"
-                    value={curso}
-                    onChange={e => setCurso(e.target.value)}
-                    placeholder=" "
-                  />
-                  <label className="fl-label">¿En qué curso estás?</label>
-                </div>
-              </Field>
-              <Field>
-                <div className="fl-field">
-                  <input
-                    className="form-control fl-input"
-                    type="number"
-                    value={experiencia}
-                    onChange={e => setExperiencia(e.target.value)}
-                    placeholder=" "
-                  />
-                  <label className="fl-label">Años de experiencia</label>
-                </div>
-              </Field>
+              {/* Curso y experiencia se solicitarán más adelante */}
               <Field style={{ gridColumn: '1 / -1' }} ref={ref}>
                 <label>Ciudad</label>
                 <DropdownContainer>

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -62,6 +62,15 @@ export async function registerProfesor(data) {
   return handleResponse(res);
 }
 
+export async function updateProfesor(data) {
+  const res = await fetch(`${API_URL}/profesor`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  return handleResponse(res);
+}
+
 export async function createOferta(data) {
   const res = await fetch(`${API_URL}/oferta`, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- allow teacher sign-up without academic or banking data
- add endpoint and client update for completing teacher profile later
- save IBAN/NIF/studies/course/experience to PostgreSQL and Firebase via modal

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a8adc78d6c832b9574a307fef7f1c3