### PR TITLE
Ordenar ofertas y mostrar tiempo desde publicación

### DIFF
--- a/bbdd/sp_bbdd.sql
+++ b/bbdd/sp_bbdd.sql
@@ -185,7 +185,7 @@ COMMENT ON TABLE student_project.profesor
 CREATE TABLE IF NOT EXISTS student_project.oferta
 (
     id_oferta serial PRIMARY KEY,
-    fecha_oferta date NOT NULL,
+    fecha_oferta timestamp NOT NULL,
     fecha_inicio date NOT NULL,
     fecha_fin date NOT NULL,
     disponibilidad VARCHAR(1000000) NOT NULL,

--- a/src/screens/alumno/acciones/NuevaClase.jsx
+++ b/src/screens/alumno/acciones/NuevaClase.jsx
@@ -487,7 +487,7 @@ export default function NuevaClase() {
     try {
       const modalidadStore = modalidad === 'presencial' ? 'Presencial' : 'Online';
       const ofertaRes = await createOferta({
-        fecha_oferta: new Date().toISOString().slice(0,10),
+        fecha_oferta: new Date().toISOString(),
         fecha_inicio: startDate,
         fecha_fin: endDate,
         disponibilidad: Array.from(selectedSlots).join(','),

--- a/src/screens/profesor/acciones/Ofertas.jsx
+++ b/src/screens/profesor/acciones/Ofertas.jsx
@@ -39,6 +39,19 @@ function formatSpanishDate(date) {
   return `${day} de ${month}`;
 }
 
+// Devuelve texto relativo en horas/días desde la creación
+function timeSince(ts) {
+  if (!ts) return '';
+  const date = ts.toDate ? ts.toDate() : new Date(ts);
+  const diffMs = Date.now() - date.getTime();
+  const hours = Math.floor(diffMs / (1000 * 60 * 60));
+  if (hours < 24) {
+    return `Hace ${hours} hora${hours !== 1 ? 's' : ''}`;
+  }
+  const days = Math.floor(hours / 24);
+  return `Hace ${days} día${days !== 1 ? 's' : ''}`;
+}
+
 // Helper: calcula semanas aproximadas entre dos fechas (YYYY-MM-DD)
 function calculateWeeks(startStr, endStr) {
   if (!startStr || !endStr) return 0;
@@ -257,6 +270,11 @@ const HeaderLeft = styled.div`
   display: flex;
   flex-direction: column;
 `;
+const TimeInfo = styled.span`
+  font-size: 0.875rem;
+  color: #666;
+  margin-bottom: 0.25rem;
+`;
 const StudentName = styled.span`
   font-size: 1.25rem;
   font-weight: 700;
@@ -423,6 +441,11 @@ export default function Ofertas() {
           disponibles.push({ id: d.id, offers: offersSnap.size, ...data });
         }
       }
+      disponibles.sort((a, b) => {
+        const aTime = a.createdAt?.toMillis ? a.createdAt.toMillis() : 0;
+        const bTime = b.createdAt?.toMillis ? b.createdAt.toMillis() : 0;
+        return aTime - bTime;
+      });
       setClases(disponibles);
     })();
   }, []);
@@ -782,6 +805,7 @@ export default function Ofertas() {
             <Card key={c.id}>
               <CardHeader>
                 <HeaderLeft>
+                  <TimeInfo>{timeSince(c.createdAt)}</TimeInfo>
                   <StudentName>
                     {shortStudentName(c.alumnoNombre)}
                   </StudentName>


### PR DESCRIPTION
## Summary
- Ordena las ofertas disponibles de más antiguas a más nuevas
- Muestra el tiempo transcurrido desde la publicación de cada oferta
- Guarda la hora exacta de creación de la oferta y actualiza el esquema de base de datos

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68a8b33bbc74832ba8746236572c60fb