### PR TITLE
Add optional student phone checkbox

### DIFF
--- a/src/components/AddChildModal.jsx
+++ b/src/components/AddChildModal.jsx
@@ -37,6 +37,7 @@ export default function AddChildModal({ open, onClose }) {
   const [cities, setCities] = useState([]);
   const [phone, setPhone] = useState('');
   const [phoneConfirm, setPhoneConfirm] = useState('');
+  const [ownPhone, setOwnPhone] = useState(false);
   const [nif, setNif] = useState('');
   const [address, setAddress] = useState('');
   const [district, setDistrict] = useState('');
@@ -56,7 +57,7 @@ export default function AddChildModal({ open, onClose }) {
       !lastName ||
         !gender ||
         !courseId ||
-        (phone && phone !== phoneConfirm) ||
+        (ownPhone && (!phone || phone !== phoneConfirm)) ||
         !nif ||
         !address ||
         !district ||
@@ -72,8 +73,8 @@ export default function AddChildModal({ open, onClose }) {
             apellidos: lastName,
             direccion: address,
             NIF: nif,
-            telefono: phone || null,
-            telefonoConfirm: phoneConfirm || null,
+            telefono: ownPhone ? phone : null,
+            telefonoConfirm: ownPhone ? phoneConfirm : null,
             genero: gender,
             id_curso: courseId,
             distrito: district,
@@ -82,7 +83,7 @@ export default function AddChildModal({ open, onClose }) {
         });
 
         const courseName = courses.find(c => c.id_curso === parseInt(courseId))?.nombre || '';
-        const finalPhone = phone || userData?.telefono || '';
+        const finalPhone = ownPhone ? phone : userData?.telefono || '';
         const nuevo = {
           id: Date.now().toString(),
           nombre: name,
@@ -106,6 +107,7 @@ export default function AddChildModal({ open, onClose }) {
       setCourseId('');
       setPhone('');
       setPhoneConfirm('');
+      setOwnPhone(false);
       setNif('');
       setAddress('');
       setDistrict('');
@@ -150,17 +152,34 @@ export default function AddChildModal({ open, onClose }) {
                 <option key={c.id_curso} value={c.id_curso}>{c.nombre}</option>
               ))}
           </SelectInput>
+          <label style={{ display: 'flex', alignItems: 'center' }}>
+            <input
+              type="checkbox"
+              checked={ownPhone}
+              onChange={e => {
+                setOwnPhone(e.target.checked);
+                if (!e.target.checked) {
+                  setPhone('');
+                  setPhoneConfirm('');
+                }
+              }}
+              style={{ marginRight: '0.5rem' }}
+            />
+            Número propio
+          </label>
           <TextInput
             type="tel"
             placeholder="Teléfono"
             value={phone}
             onChange={e => setPhone(e.target.value)}
+            disabled={!ownPhone}
           />
           <TextInput
             type="tel"
             placeholder="Repite teléfono"
             value={phoneConfirm}
             onChange={e => setPhoneConfirm(e.target.value)}
+            disabled={!ownPhone}
           />
           <TextInput
             type="text"

--- a/src/screens/SignUpTutor.jsx
+++ b/src/screens/SignUpTutor.jsx
@@ -283,6 +283,7 @@ export default function SignUpTutor() {
   const [telefonoHijo, setTelefonoHijo] = useState('');
   const [confirmTelefonoHijo, setConfirmTelefonoHijo] = useState('');
   const [telefonoHijoError, setTelefonoHijoError] = useState('');
+  const [telefonoHijoPropio, setTelefonoHijoPropio] = useState(false);
   const [direccionAlumno, setDireccionAlumno] = useState('');
   const [distritoAlumno, setDistritoAlumno] = useState('');
   const [nombreHijo, setNombreHijo] = useState('');
@@ -371,7 +372,10 @@ export default function SignUpTutor() {
     if (!barrioTutor) missing.push('Barrio, Localidad, Distrito...');
     if (!codigoPostalTutor) missing.push('Código postal facturación');
     if (!nifAlumno) missing.push('NIF del Alumno');
-    if (telefonoHijo && !confirmTelefonoHijo) missing.push('Repitir Teléfono del Alumno');
+    if (telefonoHijoPropio) {
+      if (!telefonoHijo) missing.push('Teléfono del Alumno');
+      if (!confirmTelefonoHijo) missing.push('Repitir Teléfono del Alumno');
+    }
     if (!direccionAlumno) missing.push('Dirección lugar clase');
     if (!distritoAlumno) missing.push('Barrio, Localidad, Distrito...');
     if (!nombreHijo) missing.push('Nombre del Alumno');
@@ -390,7 +394,7 @@ export default function SignUpTutor() {
       setTelefonoError('Los números no coinciden');
       return;
     }
-    if (telefonoHijo && telefonoHijo !== confirmTelefonoHijo) {
+    if (telefonoHijoPropio && telefonoHijo !== confirmTelefonoHijo) {
       setTelefonoHijoError('Los números no coinciden');
       return;
     }
@@ -433,7 +437,7 @@ export default function SignUpTutor() {
             apellidos: apellidoHijo,
             genero: generoHijo,
             curso,
-            telefono: telefonoHijo || telefono,
+            telefono: telefonoHijoPropio ? telefonoHijo : telefono,
             NIF: nifAlumno,
             direccion: direccionAlumno,
             distrito: distritoAlumno,
@@ -465,8 +469,8 @@ export default function SignUpTutor() {
           distrito: distritoAlumno,
           ciudad,
           NIF: nifAlumno,
-          telefono: telefonoHijo || null,
-          telefonoConfirm: confirmTelefonoHijo || null,
+          telefono: telefonoHijoPropio ? telefonoHijo : null,
+          telefonoConfirm: telefonoHijoPropio ? confirmTelefonoHijo : null,
           genero: generoHijo,
           id_curso: idCurso,
         }
@@ -744,12 +748,30 @@ export default function SignUpTutor() {
                 </div>
               </Field>
               <Field>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={telefonoHijoPropio}
+                    onChange={e => {
+                      setTelefonoHijoPropio(e.target.checked);
+                      if (!e.target.checked) {
+                        setTelefonoHijo('');
+                        setConfirmTelefonoHijo('');
+                        setTelefonoHijoError('');
+                      }
+                    }}
+                  />{' '}
+                  Número propio
+                </label>
+              </Field>
+              <Field>
                 <label>Teléfono del Alumno</label>
                 <PhoneInput
                   country={'es'}
                   value={telefonoHijo}
                   onChange={value => { setTelefonoHijo(value); setTelefonoHijoError(''); }}
                   inputStyle={{ width: '100%' }}
+                  disabled={!telefonoHijoPropio}
                 />
               </Field>
               <Field>
@@ -759,6 +781,7 @@ export default function SignUpTutor() {
                   value={confirmTelefonoHijo}
                   onChange={value => { setConfirmTelefonoHijo(value); setTelefonoHijoError(''); }}
                   inputStyle={{ width: '100%' }}
+                  disabled={!telefonoHijoPropio}
                 />
                 {telefonoHijoError && <ErrorText>{telefonoHijoError}</ErrorText>}
               </Field>

--- a/src/screens/alumno/acciones/MisAlumnos.jsx
+++ b/src/screens/alumno/acciones/MisAlumnos.jsx
@@ -77,6 +77,7 @@ export default function MisAlumnos() {
   const [courses, setCourses] = useState([]);
   const [phone, setPhone] = useState('');
   const [phoneConfirm, setPhoneConfirm] = useState('');
+  const [ownPhone, setOwnPhone] = useState(false);
   const [nif, setNif] = useState('');
   const [address, setAddress] = useState('');
   const [district, setDistrict] = useState('');
@@ -97,7 +98,7 @@ export default function MisAlumnos() {
       !gender ||
       !date ||
         !courseId ||
-        (phone && phone !== phoneConfirm) ||
+        (ownPhone && (!phone || phone !== phoneConfirm)) ||
         !nif ||
         !address ||
         !district ||
@@ -113,8 +114,8 @@ export default function MisAlumnos() {
             apellidos: lastName,
             direccion: address,
             NIF: nif,
-            telefono: phone || null,
-            telefonoConfirm: phoneConfirm || null,
+            telefono: ownPhone ? phone : null,
+            telefonoConfirm: ownPhone ? phoneConfirm : null,
             genero: gender,
             id_curso: courseId,
             distrito: district,
@@ -125,7 +126,7 @@ export default function MisAlumnos() {
         });
 
       const courseName = courses.find(c => c.id_curso === parseInt(courseId))?.curso || '';
-        const finalPhone = phone || userData?.telefono || '';
+        const finalPhone = ownPhone ? phone : userData?.telefono || '';
         const nuevo = {
           id: Date.now().toString(),
           nombre: name,
@@ -153,6 +154,7 @@ export default function MisAlumnos() {
       setCourseId('');
       setPhone('');
       setPhoneConfirm('');
+      setOwnPhone(false);
       setNif('');
       setAddress('');
       setDistrict('');
@@ -236,17 +238,34 @@ export default function MisAlumnos() {
               <option key={c.id_curso} value={c.id_curso}>{c.curso}</option>
             ))}
           </SelectInput>
+          <label style={{ display: 'flex', alignItems: 'center' }}>
+            <input
+              type="checkbox"
+              checked={ownPhone}
+              onChange={e => {
+                setOwnPhone(e.target.checked);
+                if (!e.target.checked) {
+                  setPhone('');
+                  setPhoneConfirm('');
+                }
+              }}
+              style={{ marginRight: '0.5rem' }}
+            />
+            Número propio
+          </label>
           <TextInput
             type="tel"
             placeholder="Teléfono"
             value={phone}
             onChange={e => setPhone(e.target.value)}
+            disabled={!ownPhone}
           />
           <TextInput
             type="tel"
             placeholder="Repite teléfono"
             value={phoneConfirm}
             onChange={e => setPhoneConfirm(e.target.value)}
+            disabled={!ownPhone}
           />
           <TextInput
             type="text"


### PR DESCRIPTION
## Summary
- Allow specifying whether a student has their own phone during tutor signup and child creation
- Use tutor's phone when no personal student number is provided

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9de07e1b0832baf791bfbc11bc439