### PR TITLE
Permitir alta de profesor sin NIF

### DIFF
--- a/node-server/index.js
+++ b/node-server/index.js
@@ -457,7 +457,7 @@ app.post('/profesor', async (req, res) => {
     genero,
     telefono,
     correo_electronico,
-    NIF,
+    NIF = null,
     direccion_facturacion,
     IBAN = null,
     carrera = null,
@@ -465,7 +465,7 @@ app.post('/profesor', async (req, res) => {
     experiencia = null,
     password,
   } = req.body;
-  if (!nombre || !apellidos || !genero || !telefono || !correo_electronico || !NIF || !direccion_facturacion || !password) {
+  if (!nombre || !apellidos || !genero || !telefono || !correo_electronico || !direccion_facturacion || !password) {
     return res.status(400).json({ error: 'Datos obligatorios faltantes' });
   }
 


### PR DESCRIPTION
## Summary
- Permite registrar profesores sin exigir NIF, dejándolo como opcional
- NIF podrá completarse posteriormente mediante la actualización del perfil

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68a9dfb53488832b806ff508af4d79b6