### PR TITLE
Ensure student info is sent for class acceptance

### DIFF
--- a/src/screens/alumno/acciones/Clases.jsx
+++ b/src/screens/alumno/acciones/Clases.jsx
@@ -196,6 +196,7 @@ export default function Clases() {
               unionId: docu.id,
               profesorId: union.profesorId,
               profesorNombre: union.profesorNombre,
+              alumnoNombre: union.alumnoNombre,
               profesorFoto,
               curso,
               ...data
@@ -269,9 +270,13 @@ export default function Clases() {
         createdAt: serverTimestamp()
       });
       await registerTransaction({
+        alumnoId: selectedChild ? selectedChild.id : auth.currentUser.uid,
         tutorId: auth.currentUser.uid,
         tutorEmail: auth.currentUser.email,
-        alumnoNombre: selectedChild ? selectedChild.nombre : '',
+        alumnoNombre:
+          selectedChild
+            ? selectedChild.nombre
+            : clase.alumnoNombre || auth.currentUser.displayName || '',
         profesorId: clase.profesorId,
         asignatura: clase.asignatura,
         modalidad: clase.modalidad,


### PR DESCRIPTION
## Summary
- Include student name when building class data so acceptance knows the alumno involved
- Send alumno ID and reliable alumno name to registerTransaction, allowing backend to insert class into PostgreSQL

## Testing
- `npm test`
- `npm --prefix node-server test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9ee8c3a24832ba41c0e5bcf5e613e