### PR TITLE
fix: disambiguate saldo column in upsert

### DIFF
--- a/node-server/index.js
+++ b/node-server/index.js
@@ -142,15 +142,15 @@ app.post('/transaccion', async (req, res) => {
     if (!profesorEmail) throw new Error('Correo del profesor no encontrado');
 
     await client.query(
-      `INSERT INTO student_project.saldo_usuario (user_id, rol, saldo)
+      `INSERT INTO student_project.saldo_usuario AS su (user_id, rol, saldo)
        VALUES ($1,'tutor',$2)
-       ON CONFLICT (user_id, rol) DO UPDATE SET saldo = saldo + EXCLUDED.saldo`,
+       ON CONFLICT (user_id, rol) DO UPDATE SET saldo = su.saldo + EXCLUDED.saldo`,
       [tutorId, -Math.abs(montoTutor || 0)]
     );
     await client.query(
-      `INSERT INTO student_project.saldo_usuario (user_id, rol, saldo)
+      `INSERT INTO student_project.saldo_usuario AS su (user_id, rol, saldo)
        VALUES ($1,'profesor',$2)
-       ON CONFLICT (user_id, rol) DO UPDATE SET saldo = saldo + EXCLUDED.saldo`,
+       ON CONFLICT (user_id, rol) DO UPDATE SET saldo = su.saldo + EXCLUDED.saldo`,
       [profesorId, montoProfesor || 0]
     );
 

--- a/src/screens/alumno/acciones/Clases.jsx
+++ b/src/screens/alumno/acciones/Clases.jsx
@@ -196,6 +196,7 @@ export default function Clases() {
               unionId: docu.id,
               profesorId: union.profesorId,
               profesorNombre: union.profesorNombre,
+              alumnoNombre: union.alumnoNombre,
               profesorFoto,
               curso,
               ...data
@@ -269,9 +270,13 @@ export default function Clases() {
         createdAt: serverTimestamp()
       });
       await registerTransaction({
+        alumnoId: selectedChild ? selectedChild.id : auth.currentUser.uid,
         tutorId: auth.currentUser.uid,
         tutorEmail: auth.currentUser.email,
-        alumnoNombre: selectedChild ? selectedChild.nombre : '',
+        alumnoNombre:
+          selectedChild
+            ? selectedChild.nombre
+            : clase.alumnoNombre || auth.currentUser.displayName || '',
         profesorId: clase.profesorId,
         asignatura: clase.asignatura,
         modalidad: clase.modalidad,


### PR DESCRIPTION
## Summary
- avoid ambiguous saldo reference in saldo_usuario upsert by aliasing table

## Testing
- `CI=true npm test -- --watchAll=false`
- `npm --prefix node-server test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a9ee8c3a24832ba41c0e5bcf5e613e