### PR TITLE
Sync bid workflow with Postgres

### DIFF
--- a/node-server/index.js
+++ b/node-server/index.js
@@ -622,6 +622,11 @@ app.post('/puja', async (req, res) => {
     );
     const pujaId = result.rows[0].id_puja;
 
+    await client.query(
+      'UPDATE student_project.oferta SET estado=$1 WHERE id_oferta=$2',
+      ['seleccion_profesor', id_oferta]
+    );
+
     for (const nombre of asignaturas) {
       const asRes = await client.query(
         'SELECT id_asignatura FROM student_project.asignatura WHERE LOWER(nombre_asignatura)=LOWER($1)',
@@ -731,7 +736,7 @@ app.post('/puja/:id/confirm', async (req, res) => {
     );
     await client.query(
       'UPDATE student_project.oferta SET estado=$1 WHERE id_oferta=$2',
-      ['enlace_creado', id_oferta]
+      ['profesor_asignado', id_oferta]
     );
     await client.query('COMMIT');
     res.json({ message: 'Enlace creado' });

--- a/src/screens/admin/acciones/GestionClases.jsx
+++ b/src/screens/admin/acciones/GestionClases.jsx
@@ -18,6 +18,7 @@ import {
 } from 'firebase/firestore';
 import { sendAssignmentEmails } from '../../../utils/email';
 import { registerPendingClass } from '../../../utils/classWorkflow';
+import { selectPuja } from '../../../utils/api';
 import { Overlay, Modal, ModalText, ModalActions, ModalButton } from '../../../components/ModalStyles';
 
 // Animación suave al cargar
@@ -257,6 +258,13 @@ export default function GestionClases() {
       precioSeleccionado: offer.precio,
       updatedAt: serverTimestamp()
     });
+    if (offer.pujaId) {
+      try {
+        await selectPuja(offer.pujaId);
+      } catch (err) {
+        console.error(err);
+      }
+    }
     await registerPendingClass({
       classId,
       offer,

--- a/src/screens/profesor/acciones/MisOfertas.jsx
+++ b/src/screens/profesor/acciones/MisOfertas.jsx
@@ -118,7 +118,7 @@ export default function MisOfertas() {
     if (processing.has(rec.id)) return;
     setProcessing(prev => new Set(prev).add(rec.id));
     try {
-      await acceptClassByTeacher(rec.id, rec.studentEmail, rec.alumnoNombre);
+      await acceptClassByTeacher(rec.id, rec.studentEmail, rec.alumnoNombre, rec.pujaId);
       setAssignments(as => as.map(a => a.id === rec.id ? { ...a, estado: 'espera_alumno' } : a));
     } finally {
       setProcessing(prev => { const s = new Set(prev); s.delete(rec.id); return s; });

--- a/src/utils/classWorkflow.js
+++ b/src/utils/classWorkflow.js
@@ -1,6 +1,7 @@
 import { db } from '../firebase/firebaseConfig';
 import { collection, addDoc, serverTimestamp, updateDoc, doc, deleteDoc } from 'firebase/firestore';
 import { sendAssignmentEmails } from './email';
+import { acceptPuja, confirmPuja } from './api';
 
 export async function registerPendingClass({ classId, offer, alumnoId, alumnoNombre, padreNombre, hijoId }) {
   await addDoc(collection(db, 'registro_clases'), {
@@ -12,12 +13,13 @@ export async function registerPendingClass({ classId, offer, alumnoId, alumnoNom
     profesorNombre: offer.profesorNombre,
     padreNombre: padreNombre || null,
     hijoId: hijoId || null,
+    pujaId: offer.pujaId || null,
     estado: 'espera_profesor',
     createdAt: serverTimestamp(),
   });
 }
 
-export async function acceptClassByTeacher(recordId, studentEmail, studentName) {
+export async function acceptClassByTeacher(recordId, studentEmail, studentName, pujaId) {
   const ref = doc(db, 'registro_clases', recordId);
   await updateDoc(ref, { estado: 'espera_alumno', acceptedByTeacher: serverTimestamp() });
   await sendAssignmentEmails({
@@ -25,11 +27,25 @@ export async function acceptClassByTeacher(recordId, studentEmail, studentName) 
     studentName,
     recipient: 'student',
   });
+  if (pujaId) {
+    try {
+      await acceptPuja(pujaId);
+    } catch (err) {
+      console.error(err);
+    }
+  }
 }
 
 export async function acceptClassByStudent(recordId, data) {
   const ref = doc(db, 'registro_clases', recordId);
   await deleteDoc(ref);
+  if (data.pujaId) {
+    try {
+      await confirmPuja(data.pujaId);
+    } catch (err) {
+      console.error(err);
+    }
+  }
   await addDoc(collection(db, 'clases_union'), {
     claseId: data.claseId,
     offerId: data.offerId,


### PR DESCRIPTION
## Summary
- Store each professor bid's Postgres ID in Firestore
- Update admin selection, teacher acceptance, and student confirmation to reflect in Postgres
- Track offer state transitions through the whole bidding process

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa56850810832b8f0d8488f4e5108c