### PR TITLE
Refine progress flow for student classes

### DIFF
--- a/src/components/ProgressBar.jsx
+++ b/src/components/ProgressBar.jsx
@@ -33,8 +33,8 @@ const Fill = styled.div`
     rgba(255,255,255,0) 100%
   );
   background-size: 40px 100%;
-  animation: ${shimmer} 4s linear infinite;
-  transition: width 2s ease;
+  animation: ${shimmer} 3.5s linear infinite;
+  transition: width 3.5s ease;
   border-radius: 8px;
 `;
 

--- a/src/components/ProgressBar.jsx
+++ b/src/components/ProgressBar.jsx
@@ -33,8 +33,8 @@ const Fill = styled.div`
     rgba(255,255,255,0) 100%
   );
   background-size: 40px 100%;
-  animation: ${shimmer} 2s linear infinite;
-  transition: width 0.6s ease;
+  animation: ${shimmer} 4s linear infinite;
+  transition: width 2s ease;
   border-radius: 8px;
 `;
 
@@ -87,7 +87,13 @@ const Labels = styled.div`
 `;
 
 export default function ProgressBar({ percent, color, label }) {
-  const steps = ['Solicitud', 'Búsqueda de profesor', 'Selección de profesor', 'Esperando respuesta del profesor'];
+  const steps = [
+    'Solicitud',
+    'Búsqueda de profesor',
+    'Selección de profesor',
+    'Esperando respuesta del profesor',
+    'Profesor asignado'
+  ];
   const stepPercents = steps.map((_, i) => (i / (steps.length - 1)) * 100);
 
   return (

--- a/src/screens/alumno/acciones/Clases.jsx
+++ b/src/screens/alumno/acciones/Clases.jsx
@@ -137,13 +137,13 @@ const RejectButton = styled.button`
 const getProgressData = s => {
   if (s.estado === 'pendiente') {
     return s.offers === 0
-      ? { percent: 33.3, color: '#e53e3e', label: 'En búsqueda de profesor' }
-      : { percent: 66.6, color: '#dd6b20', label: 'En selección de profesor' };
+      ? { percent: 25, color: '#e53e3e', label: 'En búsqueda de profesor' }
+      : { percent: 50, color: '#dd6b20', label: 'En selección de profesor' };
   }
   if (s.estado === 'en_proceso') {
-    return { percent: 100, color: '#3182ce', label: 'Esperando respuesta del profesor' };
+    return { percent: 75, color: '#3182ce', label: 'Esperando respuesta del profesor' };
   }
-  return { percent: 0, color: '#38a169', label: 'Profesor asignado' };
+  return { percent: 100, color: '#38a169', label: 'Profesor asignado' };
 };
 
 export default function Clases() {

--- a/src/screens/profesor/acciones/Ofertas.jsx
+++ b/src/screens/profesor/acciones/Ofertas.jsx
@@ -4,7 +4,6 @@ import styled, { keyframes } from 'styled-components';
 import { useNotification } from '../../../NotificationContext';
 import { auth, db } from '../../../firebase/firebaseConfig';
 import InfoGrid from '../../../components/InfoGrid';
-import ProgressBar from '../../../components/ProgressBar';
 import { useAuth } from '../../../AuthContext';
 import CompleteTeacherProfileModal from '../../../components/CompleteTeacherProfileModal';
 import {
@@ -378,10 +377,19 @@ const SlotCell = styled.div`
   transition: background 0.2s, border 0.2s;
 `;
 
+const StatusText = styled.div`
+  margin: 0.5rem 0;
+  font-weight: 600;
+  color: ${p => p.color};
+`;
+
 const getProgressData = c => {
+  if (c.estado && c.estado !== 'pendiente') {
+    return { percent: 100, color: '#38a169', label: 'Profesor asignado' };
+  }
   return c.offers === 0
-    ? { percent: 33.3, color: '#e53e3e', label: 'En búsqueda de profesor' }
-    : { percent: 66.6, color: '#dd6b20', label: 'En selección de profesor' };
+    ? { percent: 25, color: '#e53e3e', label: 'En búsqueda de profesor' }
+    : { percent: 50, color: '#dd6b20', label: 'En selección de profesor' };
 };
 
 export default function Ofertas() {
@@ -877,9 +885,9 @@ export default function Ofertas() {
               ))}
             </div>
 
-            {c.estado === 'pendiente' && (
-              <ProgressBar {...getProgressData(c)} />
-            )}
+            <StatusText color={getProgressData(c).color}>
+              {getProgressData(c).label}
+            </StatusText>
 
               <Controls>
                 <ShowScheduleText onClick={() => toggleExpand(c.id)}>


### PR DESCRIPTION
## Summary
- extend progress bar with final "Profesor asignado" step and slow animation
- show progress bar only to students; professors see status text instead
- adjust student progress mapping to include new step percentages

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68aa5a5f5844832b80ae646c6aafa796