### PR TITLE
Asignación de avatar aleatorio y selector de avatares

### DIFF
--- a/src/screens/SignUpProfesor.jsx
+++ b/src/screens/SignUpProfesor.jsx
@@ -12,7 +12,8 @@ import { Overlay, Modal, ModalText, ModalActions, ModalButton } from '../compone
 
 // Firebase (inicializado en firebaseConfig.js)
 import { auth, db } from '../firebase/firebaseConfig';
-import { createUserWithEmailAndPassword, sendEmailVerification, deleteUser } from 'firebase/auth';
+import { createUserWithEmailAndPassword, sendEmailVerification, deleteUser, updateProfile } from 'firebase/auth';
+import { getRandomAvatar } from '../utils/avatars';
 import { collection, getDocs, doc, setDoc, deleteDoc, query, where } from 'firebase/firestore';
 
 // Animación de entrada
@@ -372,6 +373,8 @@ export default function SignUpProfesor() {
       }
       const { user } = await createUserWithEmailAndPassword(auth, email, password);
       authUser = user;
+      const avatar = getRandomAvatar();
+      await updateProfile(user, { photoURL: avatar });
       await setDoc(doc(db, 'usuarios', user.uid), {
         uid: user.uid,
         email,
@@ -388,6 +391,7 @@ export default function SignUpProfesor() {
         barrio,
         codigo_postal: codigoPostal,
         IBAN: null,
+        photoURL: avatar,
         carrera: null,
         curso: null,
         experiencia: null,

--- a/src/screens/SignUpTutor.jsx
+++ b/src/screens/SignUpTutor.jsx
@@ -16,7 +16,8 @@ import { Overlay, Modal, ModalText, ModalActions, ModalButton } from '../compone
 
 // Firebase (inicializado en firebaseConfig.js)
 import { auth, db } from '../firebase/firebaseConfig';
-import { createUserWithEmailAndPassword, sendEmailVerification, deleteUser } from 'firebase/auth';
+import { createUserWithEmailAndPassword, sendEmailVerification, deleteUser, updateProfile } from 'firebase/auth';
+import { getRandomAvatar } from '../utils/avatars';
 import { collection, getDocs, doc, setDoc, deleteDoc, query, where } from 'firebase/firestore';
 
 // Animación de entrada
@@ -414,6 +415,8 @@ export default function SignUpTutor() {
       }
       const { user } = await createUserWithEmailAndPassword(auth, email, password);
       authUser = user;
+      const avatar = getRandomAvatar();
+      await updateProfile(user, { photoURL: avatar });
       const data = {
         uid: user.uid,
         email,
@@ -430,6 +433,7 @@ export default function SignUpTutor() {
         barrio: barrioTutor,
         codigo_postal: codigoPostalTutor,
         createdAt: new Date(),
+        photoURL: avatar,
         alumnos: [
           {
             id: Date.now().toString(),
@@ -441,7 +445,7 @@ export default function SignUpTutor() {
             NIF: nifAlumno,
             direccion: direccionAlumno,
             distrito: distritoAlumno,
-            photoURL: user.photoURL || ''
+            photoURL: avatar
           },
         ]
       };

--- a/src/screens/shared/Perfil.jsx
+++ b/src/screens/shared/Perfil.jsx
@@ -15,6 +15,7 @@ import {
 } from 'firebase/firestore';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import cameraIcon from '../../assets/icons/camara.png';
+import avatars from '../../utils/avatars';
 import {
   BarChart,
   Bar,
@@ -179,6 +180,27 @@ const EditButton = styled.button`
   }
 `;
 
+const AvatarGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  max-height: 200px;
+  overflow-y: auto;
+`;
+
+const AvatarOption = styled.img`
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  cursor: pointer;
+  object-fit: cover;
+  border: 2px solid transparent;
+  &:hover {
+    border-color: #006D5B;
+  }
+`;
+
 const InlineInput = styled.input`
   display: block;
   width: 100%;
@@ -238,6 +260,7 @@ export default function Perfil() {
   const [role, setRole] = useState(null); // 'alumno' o 'profesor'
   const [unions, setUnions] = useState([]); // todas las uniones del usuario
   const [acceptedClasses, setAcceptedClasses] = useState([]); // solo las clases aceptadas
+  const [showAvatarPicker, setShowAvatarPicker] = useState(false);
   const [metrics, setMetrics] = useState({
     totalHoras: 0,
     totalGanado: 0,
@@ -286,6 +309,7 @@ export default function Perfil() {
       status: formData.status,
       iban: formData.iban,
     }));
+    setShowAvatarPicker(false);
     setIsEditing(false);
   };
 
@@ -299,6 +323,12 @@ export default function Perfil() {
     const url = await getDownloadURL(storageRef);
     await updateDoc(doc(db, 'usuarios', userId), { photoURL: url });
     setProfile(p => ({ ...p, photoURL: url }));
+  };
+
+  const handleAvatarSelect = async url => {
+    await updateDoc(doc(db, 'usuarios', userId), { photoURL: url });
+    setProfile(p => ({ ...p, photoURL: url }));
+    setShowAvatarPicker(false);
   };
 
   const addChild = async () => {
@@ -524,6 +554,25 @@ export default function Perfil() {
           </PhotoWrapper>
           <div>
             {isOwnProfile && <p>{profile.email}</p>}
+            {isOwnProfile && isEditing && (
+              <>
+                <EditButton type="button" onClick={() => setShowAvatarPicker(!showAvatarPicker)}>
+                  Elegir avatar
+                </EditButton>
+                {showAvatarPicker && (
+                  <AvatarGrid>
+                    {avatars.map(a => (
+                      <AvatarOption
+                        key={a.name}
+                        src={a.src}
+                        alt={a.name}
+                        onClick={() => handleAvatarSelect(a.src)}
+                      />
+                    ))}
+                  </AvatarGrid>
+                )}
+              </>
+            )}
             {isOwnProfile && (
               isEditing ? (
                 <>

--- a/src/utils/avatars.js
+++ b/src/utils/avatars.js
@@ -1,0 +1,10 @@
+const avatarsContext = require.context('../assets/avataressp', false, /\.(png|jpe?g)$/);
+const avatars = avatarsContext.keys().map((key) => {
+  const src = avatarsContext(key);
+  const name = key.replace('./', '').replace(/\.\w+$/, '');
+  return { name, src };
+});
+export function getRandomAvatar() {
+  return avatars[Math.floor(Math.random() * avatars.length)].src;
+}
+export default avatars;


### PR DESCRIPTION
## Resumen
- Asigna un avatar aleatorio al registrarse profesores y tutores, actualizando sus datos de perfil.
- Añade utilidad para gestionar el listado de avatares disponibles.
- Permite cambiar la foto de perfil desde la pantalla de perfil mediante un selector de avatares.

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68aa6f6464fc832bb0a3d4d2a6d1cfcc