### PR TITLE
Format dates in Spanish style

### DIFF
--- a/src/screens/admin/PanelAdmin.jsx
+++ b/src/screens/admin/PanelAdmin.jsx
@@ -15,6 +15,7 @@ import GestionClases from './acciones/GestionClases';
 import Facturacion   from './acciones/Facturacion';
 import Usuarios      from './acciones/Usuarios';
 import Pagos        from './acciones/Pagos';
+import { formatDate } from '../../utils/formatDate';
 
 const Container = styled.div`
   display: flex;
@@ -144,7 +145,7 @@ export default function PanelAdmin() {
             data.asignatura ||
             classData.asignatura ||
             (classData.asignaturas || []).join(', '),
-          fecha: data.fecha || '',
+          fecha: data.fecha ? formatDate(data.fecha) : '',
           duracion: data.duracion || '',
           modalidad: data.modalidad || '',
           tipoClase: classData.tipoClase || '',

--- a/src/screens/admin/acciones/Facturacion.jsx
+++ b/src/screens/admin/acciones/Facturacion.jsx
@@ -3,6 +3,7 @@ import styled, { keyframes } from 'styled-components';
 import { PrimaryButton, DangerButton, TextInput } from '../../../components/FormElements';
 import { db } from '../../../firebase/firebaseConfig';
 import { collection, getDocs, addDoc, deleteDoc, doc } from 'firebase/firestore';
+import { formatDate } from '../../../utils/formatDate';
 
 const fade = keyframes`from{opacity:0;transform:translateY(-10px);}to{opacity:1;transform:translateY(0);}`;
 
@@ -65,7 +66,7 @@ export default function Facturacion(){
         </Form>
         {items.map(i=>(
           <Item key={i.id}>
-            <span>{i.fecha} - {i.mensaje}</span>
+            <span>{formatDate(i.fecha)} - {i.mensaje}</span>
             <DangerButton onClick={()=>removeItem(i.id)}>Eliminar</DangerButton>
           </Item>
         ))}

--- a/src/screens/admin/acciones/GestionClases.jsx
+++ b/src/screens/admin/acciones/GestionClases.jsx
@@ -20,6 +20,7 @@ import { sendAssignmentEmails } from '../../../utils/email';
 import { registerPendingClass } from '../../../utils/classWorkflow';
 import { selectPuja } from '../../../utils/api';
 import { Overlay, Modal, ModalText, ModalActions, ModalButton } from '../../../components/ModalStyles';
+import { formatDate } from '../../../utils/formatDate';
 
 // Animación suave al cargar
 const fadeDown = keyframes`
@@ -344,25 +345,13 @@ export default function GestionClases() {
                 <div>
                   <Label>Fecha inicio:</Label>{' '}
                   <Value>
-                    {c.fechaInicio
-                      ? new Date(c.fechaInicio).toLocaleDateString('es-ES', {
-                          day: '2-digit',
-                          month: '2-digit',
-                          year: 'numeric'
-                        })
-                      : '—'}
+                    {c.fechaInicio ? formatDate(c.fechaInicio) : '—'}
                   </Value>
                 </div>
                 <div>
                   <Label>Fecha fin:</Label>{' '}
                   <Value>
-                    {c.fechaFin
-                      ? new Date(c.fechaFin).toLocaleDateString('es-ES', {
-                          day: '2-digit',
-                          month: '2-digit',
-                          year: 'numeric'
-                        })
-                      : '—'}
+                    {c.fechaFin ? formatDate(c.fechaFin) : '—'}
                   </Value>
                 </div>
                 <div>

--- a/src/screens/admin/acciones/Profesores.jsx
+++ b/src/screens/admin/acciones/Profesores.jsx
@@ -10,6 +10,7 @@ import {
   doc,
   updateDoc
 } from 'firebase/firestore';
+import { formatDate } from '../../../utils/formatDate';
 
 const fadeIn = keyframes`
   from { opacity: 0; transform: translateY(-10px); }
@@ -169,7 +170,7 @@ export default function Profesores() {
               classes.map((cl) => (
                 <ClassCard key={cl.id}>
                   <p><strong>Alumno:</strong> {cl.alumnoNombre} {cl.alumnoApellidos}</p>
-                  <p><strong>Fecha:</strong> {cl.fecha} {cl.hora}</p>
+                  <p><strong>Fecha:</strong> {formatDate(cl.fecha)} {cl.hora}</p>
                   <p><strong>Asignatura:</strong> {cl.asignatura}</p>
                   <p><strong>Duración:</strong> {cl.duracion} h</p>
                 </ClassCard>

--- a/src/screens/alumno/acciones/Clases.jsx
+++ b/src/screens/alumno/acciones/Clases.jsx
@@ -22,6 +22,7 @@ import {
 } from 'firebase/firestore';
 import { acceptClassByStudent, rejectPendingClass } from '../../../utils/classWorkflow';
 import { registerTransaction } from "../../../utils/api";
+import { formatDate } from '../../../utils/formatDate';
 
 const fadeIn = keyframes`
   from { opacity: 0; transform: translateY(-10px); }
@@ -265,7 +266,7 @@ export default function Clases() {
       });
       await addDoc(collection(db, 'clases_union', clase.unionId, 'chats'), {
         senderId: clase.profesorId,
-        text: `He añadido una clase, ${clase.fecha} a las ${clase.hora}`,
+        text: `He añadido una clase, ${formatDate(clase.fecha)} a las ${clase.hora}`,
         createdAt: serverTimestamp()
       });
       await registerTransaction({
@@ -332,7 +333,7 @@ export default function Clases() {
       });
       await addDoc(collection(db, 'clases_union', clase.unionId, 'chats'), {
         senderId: auth.currentUser.uid,
-        text: `He aceptado la modificación para el ${clase.fecha}`,
+        text: `He aceptado la modificación para el ${formatDate(clase.fecha)}`,
         createdAt: serverTimestamp()
       });
       setClases(prev => prev.map(c =>
@@ -358,7 +359,7 @@ export default function Clases() {
       });
       await addDoc(collection(db, 'clases_union', clase.unionId, 'chats'), {
         senderId: auth.currentUser.uid,
-        text: `He rechazado la modificación para el ${clase.fecha}`,
+        text: `He rechazado la modificación para el ${formatDate(clase.fecha)}`,
         createdAt: serverTimestamp()
       });
       setClases(prev => prev.map(c =>
@@ -416,10 +417,6 @@ export default function Clases() {
     return arr;
   }, [clases, sortBy]);
 
-  const formatDate = d => {
-    return d ? new Date(d).toLocaleDateString('es-ES', { day: '2-digit', month: '2-digit', year: 'numeric' }) : '—';
-  };
-
   return (
     <Page>
       <Container>
@@ -467,7 +464,7 @@ export default function Clases() {
                       <Label>Curso:</Label> <Value>{c.curso || '-'}</Value>
                     </div>
                     <div>
-                      <Label>Fecha:</Label> <Value>{c.fecha} {c.hora}</Value>
+                      <Label>Fecha:</Label> <Value>{formatDate(c.fecha)} {c.hora}</Value>
                     </div>
                     <div>
                       <Label>Modalidad:</Label> <Value>{c.modalidad}</Value>

--- a/src/screens/alumno/acciones/MisProfesores.jsx
+++ b/src/screens/alumno/acciones/MisProfesores.jsx
@@ -19,6 +19,7 @@ import {
   doc
 } from 'firebase/firestore';
 import { useNavigate } from 'react-router-dom';
+import { formatDate } from '../../../utils/formatDate';
 
 // Animación de entrada
 const fadeIn = keyframes`
@@ -359,7 +360,7 @@ export default function MisProfesores() {
         collection(db, 'clases_union', chatUnionId, 'chats'),
         {
           senderId: union.profesorId,
-          text: `Clase confirmada de ${proposal.asignatura} el dia ${proposal.fecha}`,
+          text: `Clase confirmada de ${proposal.asignatura} el dia ${formatDate(proposal.fecha)}`,
           createdAt: serverTimestamp()
         }
       );
@@ -394,12 +395,12 @@ export default function MisProfesores() {
     if (union) {
       await addDoc(collection(db, 'clases_union', chatUnionId, 'chats'), {
         senderId: auth.currentUser.uid,
-        text: `He aceptado la modificación para el ${mod.fecha}`,
+        text: `He aceptado la modificación para el ${formatDate(mod.fecha)}`,
         createdAt: serverTimestamp()
       });
       await addDoc(collection(db, 'notificaciones'), {
         userId: union.profesorId,
-        text: `Modificación de clase aceptada para ${mod.fecha}`,
+        text: `Modificación de clase aceptada para ${formatDate(mod.fecha)}`,
         read: false,
         createdAt: serverTimestamp()
       });
@@ -479,7 +480,7 @@ export default function MisProfesores() {
                       <Bubble mine={mine}>
                         <div>
                           El profesor ha añadido una clase de <strong> {item.asignatura}</strong> el{' '}
-                          <strong>{item.fecha}</strong> a las <strong>{item.hora}</strong> ({item.duracion}h)
+                        <strong>{formatDate(item.fecha)}</strong> a las <strong>{item.hora}</strong> ({item.duracion}h)
                         </div>
                         <div>Coste: €{(item.precioTotalPadres || 0).toFixed(2)}</div>
                         <AcceptButton onClick={() => acceptProposal(item)}>
@@ -506,7 +507,7 @@ export default function MisProfesores() {
                       <Sender>{mine ? 'Tú (Cambio)' : 'Profesor (Cambio)'}</Sender>
                       <Bubble mine={mine}>
                         <div>
-                          Nueva fecha: <strong>{item.fecha}</strong> ({item.duracion}h)
+                          Nueva fecha: <strong>{formatDate(item.fecha)}</strong> ({item.duracion}h)
                         </div>
                         <AcceptButton onClick={() => acceptModification(item)}>
                           Aceptar cambio

--- a/src/screens/profesor/acciones/Clases.jsx
+++ b/src/screens/profesor/acciones/Clases.jsx
@@ -20,6 +20,7 @@ import {
   serverTimestamp,
   onSnapshot
 } from 'firebase/firestore';
+import { formatDate } from '../../../utils/formatDate';
 
 import MisOfertas from './MisOfertas';
 
@@ -302,12 +303,12 @@ export default function ClasesProfesor() {
     });
     await addDoc(collection(db, 'clases_union', editing.unionId, 'chats'), {
       senderId: auth.currentUser.uid,
-      text: `He modificado la clase del día ${editing.fecha} de duración ${editing.duracion}h a ${newDate} con duración ${newDuration}h`,
+      text: `He modificado la clase del día ${formatDate(editing.fecha)} de duración ${editing.duracion}h a ${formatDate(newDate)} con duración ${newDuration}h`,
       createdAt: serverTimestamp()
     });
     await addDoc(collection(db, 'notificaciones'), {
       userId: editing.alumnoId,
-      text: `Se modificó la clase del ${editing.fecha}`,
+      text: `Se modificó la clase del ${formatDate(editing.fecha)}`,
       read: false,
       createdAt: serverTimestamp()
     });
@@ -379,7 +380,7 @@ export default function ClasesProfesor() {
                     <Label>Curso:</Label> <Value>{c.curso || '-'}</Value>
                   </div>
                   <div>
-                    <Label>Fecha:</Label> <Value>{c.fecha} {c.hora}</Value>
+                    <Label>Fecha:</Label> <Value>{formatDate(c.fecha)} {c.hora}</Value>
                   </div>
                   <div>
                     <Label>Modalidad:</Label> <Value>{c.modalidad}</Value>

--- a/src/screens/profesor/acciones/MisAlumnos.jsx
+++ b/src/screens/profesor/acciones/MisAlumnos.jsx
@@ -16,6 +16,7 @@ import {
   doc
 } from 'firebase/firestore';
 import { useNavigate } from 'react-router-dom';
+import { formatDate } from '../../../utils/formatDate';
 
 // Animación de entrada
 const fadeIn = keyframes`
@@ -595,7 +596,7 @@ export default function MisAlumnos() {
                         </div>
                         <div>
                           <strong>{item.asignatura}</strong> el{' '}
-                          <strong>{item.fecha}</strong> a las <strong>{item.hora}</strong> ({item.duracion}h)
+                          <strong>{formatDate(item.fecha)}</strong> a las <strong>{item.hora}</strong> ({item.duracion}h)
                         </div>
                         {item.estado === 'pendiente' && (
                           <CancelButton onClick={() => cancelProposal(item)}>

--- a/src/screens/profesor/acciones/Ofertas.jsx
+++ b/src/screens/profesor/acciones/Ofertas.jsx
@@ -20,6 +20,7 @@ import {
 } from 'firebase/firestore';
 import { createPuja } from '../../../utils/api';
 import { Overlay, Modal, ModalText, ModalActions, ModalButton } from '../../../components/ModalStyles';
+import { formatDate } from '../../../utils/formatDate';
 
 // Animación de fade-in al desplegar
 const fadeDown = keyframes`
@@ -27,17 +28,6 @@ const fadeDown = keyframes`
   to   { opacity: 1; transform: translateY(0); }
 `;
 
-// Helper: formatea Date como "D de mes" en español
-function formatSpanishDate(date) {
-  if (!date) return '';
-  const months = [
-    'enero','febrero','marzo','abril','mayo','junio',
-    'julio','agosto','septiembre','octubre','noviembre','diciembre'
-  ];
-  const day = date.getDate();
-  const month = months[date.getMonth()];
-  return `${day} de ${month}`;
-}
 
 // Devuelve texto relativo en horas/días desde la creación
 function timeSince(ts) {
@@ -623,8 +613,8 @@ export default function Ofertas() {
     setInfoModal(true);
 
     // Construir el texto de notificación
-    const inicioTxt = clase.fechaInicio ? formatSpanishDate(new Date(clase.fechaInicio)) : '—';
-    const finTxt = clase.fechaFin ? formatSpanishDate(new Date(clase.fechaFin)) : '—';
+    const inicioTxt = clase.fechaInicio ? formatDate(clase.fechaInicio) : '—';
+    const finTxt = clase.fechaFin ? formatDate(clase.fechaFin) : '—';
     const duration = calculateWeeks(clase.fechaInicio, clase.fechaFin);
     const durTxt = `${duration} ${duration === 1 ? 'semana' : 'semanas'}`;
     const firstName = clase.alumnoNombre?.split(' ')[0] || '';
@@ -849,11 +839,11 @@ export default function Ofertas() {
                 )}
                 <div>
                   <Label>Fecha inicio:</Label>{' '}
-                  <Value>{inicioDate ? formatSpanishDate(inicioDate) : '—'}</Value>
+                  <Value>{inicioDate ? formatDate(inicioDate) : '—'}</Value>
                 </div>
                 <div>
                   <Label>Fecha fin:</Label>{' '}
-                  <Value>{finDate ? formatSpanishDate(finDate) : '—'}</Value>
+                  <Value>{finDate ? formatDate(finDate) : '—'}</Value>
                 </div>
                 <div>
                   <Label>Duración aprox.:</Label>{' '}
@@ -953,9 +943,9 @@ export default function Ofertas() {
                 ))}
                 <br/>
                 <strong>Fecha inicio:</strong>{' '}
-                {selected.fechaInicio ? formatSpanishDate(new Date(selected.fechaInicio)) : '—'}<br/>
+                {selected.fechaInicio ? formatDate(selected.fechaInicio) : '—'}<br/>
                 <strong>Fecha fin:</strong>{' '}
-                {selected.fechaFin ? formatSpanishDate(new Date(selected.fechaFin)) : '—'}<br/>
+                {selected.fechaFin ? formatDate(selected.fechaFin) : '—'}<br/>
                 <strong>Duración aprox.:</strong> {calculateWeeks(selected.fechaInicio, selected.fechaFin)} {calculateWeeks(selected.fechaInicio, selected.fechaFin) === 1 ? 'semana' : 'semanas'}<br/>
                 <strong>Horas/semana:</strong> {selected.horasSemana} <em>(aprox.)</em><br/><br/>
                 <strong>Horario de TÚ DISPONIBILIDAD:</strong><br/>

--- a/src/screens/shared/Perfil.jsx
+++ b/src/screens/shared/Perfil.jsx
@@ -28,6 +28,7 @@ import {
 import { useChild } from '../../ChildContext';
 import { TextInput, SelectInput, PrimaryButton } from '../../components/FormElements';
 import InfoGrid from '../../components/InfoGrid';
+import { formatDate } from '../../utils/formatDate';
 
 // Animación de fade-in
 const fadeIn = keyframes`
@@ -718,7 +719,7 @@ export default function Perfil() {
                     {profile.photoURL && <ChildImg src={profile.photoURL} alt="foto" />}
                     <div>
                       <div>{h.nombre}</div>
-                      <div style={{ fontSize: '0.8rem', color: '#555' }}>{h.fechaNacimiento}</div>
+                      <div style={{ fontSize: '0.8rem', color: '#555' }}>{formatDate(h.fechaNacimiento)}</div>
                     </div>
                   </ChildItem>
                 ))}

--- a/src/utils/formatDate.js
+++ b/src/utils/formatDate.js
@@ -1,0 +1,10 @@
+import { format } from 'date-fns';
+
+export function formatDate(value) {
+  if (!value) return '—';
+  const date = value instanceof Date ? value : new Date(value);
+  if (isNaN(date)) return '—';
+  return format(date, 'dd/MM/yyyy');
+}
+
+export default formatDate;


### PR DESCRIPTION
## Summary
- Ensure all front-end dates display as DD/MM/YYYY using new `formatDate` utility
- Replace direct date strings across screens with consistent formatter

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68aa708b2750832b87d4aefda214467c