### PR TITLE
Align student phone input with tutor registration

### DIFF
--- a/src/components/AddChildModal.jsx
+++ b/src/components/AddChildModal.jsx
@@ -7,6 +7,8 @@ import { useChild } from '../ChildContext';
 import { useAuth } from '../AuthContext';
 import { fetchCursos, fetchCities, registerAlumno } from '../utils/api';
 import { Overlay, Modal, ModalTitle } from './ModalStyles';
+import PhoneInput from 'react-phone-input-2';
+import 'react-phone-input-2/lib/style.css';
 
 const CloseButton = styled.button`
   position: absolute;
@@ -169,17 +171,19 @@ export default function AddChildModal({ open, onClose }) {
           </label>
           {ownPhone && (
             <>
-              <TextInput
-                type="tel"
-                placeholder="Teléfono"
+              <PhoneInput
+                country={'es'}
                 value={phone}
-                onChange={e => setPhone(e.target.value)}
+                onChange={value => setPhone(value)}
+                inputStyle={{ width: '100%' }}
+                placeholder="Teléfono"
               />
-              <TextInput
-                type="tel"
-                placeholder="Repite teléfono"
+              <PhoneInput
+                country={'es'}
                 value={phoneConfirm}
-                onChange={e => setPhoneConfirm(e.target.value)}
+                onChange={value => setPhoneConfirm(value)}
+                inputStyle={{ width: '100%' }}
+                placeholder="Repite teléfono"
               />
             </>
           )}

--- a/src/screens/alumno/acciones/MisAlumnos.jsx
+++ b/src/screens/alumno/acciones/MisAlumnos.jsx
@@ -7,6 +7,8 @@ import { useChild } from '../../../ChildContext';
 import { useAuth } from '../../../AuthContext';
 import { Overlay, Modal, ModalText, ModalActions, ModalButton } from '../../../components/ModalStyles';
 import { fetchCursos, registerAlumno } from '../../../utils/api';
+import PhoneInput from 'react-phone-input-2';
+import 'react-phone-input-2/lib/style.css';
 
 const fadeIn = keyframes`
   from { opacity: 0; transform: translateY(-10px); }
@@ -255,17 +257,19 @@ export default function MisAlumnos() {
           </label>
           {ownPhone && (
             <>
-              <TextInput
-                type="tel"
-                placeholder="Teléfono"
+              <PhoneInput
+                country={'es'}
                 value={phone}
-                onChange={e => setPhone(e.target.value)}
+                onChange={value => setPhone(value)}
+                inputStyle={{ width: '100%' }}
+                placeholder="Teléfono"
               />
-              <TextInput
-                type="tel"
-                placeholder="Repite teléfono"
+              <PhoneInput
+                country={'es'}
                 value={phoneConfirm}
-                onChange={e => setPhoneConfirm(e.target.value)}
+                onChange={value => setPhoneConfirm(value)}
+                inputStyle={{ width: '100%' }}
+                placeholder="Repite teléfono"
               />
             </>
           )}


### PR DESCRIPTION
## Summary
- Reuse react-phone-input-2 component for student phone fields in tutor panel
- Apply consistent phone number validation and styling to student registration forms

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68aae6d476b8832bbdccf713e429c436