### PR TITLE
Add tutor response state to class progress workflow

### DIFF
--- a/src/components/ProgressBar.jsx
+++ b/src/components/ProgressBar.jsx
@@ -92,6 +92,7 @@ export default function ProgressBar({ percent, color, label }) {
     'Búsqueda de profesor',
     'Selección de profesor',
     'Esperando respuesta del profesor',
+    'Esperando respuesta del tutor',
     'Profesor asignado'
   ];
   const stepPercents = steps.map((_, i) => (i / (steps.length - 1)) * 100);

--- a/src/screens/alumno/acciones/Clases.jsx
+++ b/src/screens/alumno/acciones/Clases.jsx
@@ -138,11 +138,14 @@ const RejectButton = styled.button`
 const getProgressData = s => {
   if (s.estado === 'pendiente') {
     return s.offers === 0
-      ? { percent: 25, color: '#e53e3e', label: 'En búsqueda de profesor' }
-      : { percent: 50, color: '#dd6b20', label: 'En selección de profesor' };
+      ? { percent: 20, color: '#e53e3e', label: 'En búsqueda de profesor' }
+      : { percent: 40, color: '#dd6b20', label: 'En selección de profesor' };
   }
   if (s.estado === 'en_proceso') {
-    return { percent: 75, color: '#3182ce', label: 'Esperando respuesta del profesor' };
+    return { percent: 60, color: '#3182ce', label: 'Esperando respuesta del profesor' };
+  }
+  if (s.estado === 'espera_alumno') {
+    return { percent: 80, color: '#805ad5', label: 'Esperando respuesta del tutor' };
   }
   return { percent: 100, color: '#38a169', label: 'Profesor asignado' };
 };

--- a/src/utils/classWorkflow.js
+++ b/src/utils/classWorkflow.js
@@ -24,6 +24,13 @@ export async function acceptClassByTeacher(recordId, studentEmail, pujaId) {
   const snap = await getDoc(ref);
   const data = snap.exists() ? snap.data() : {};
   await updateDoc(ref, { estado: 'espera_alumno', acceptedByTeacher: serverTimestamp() });
+  try {
+    if (data.claseId) {
+      await updateDoc(doc(db, 'clases', data.claseId), { estado: 'espera_alumno' });
+    }
+  } catch (err) {
+    console.error(err);
+  }
   let teacherCareer = '';
   try {
     if (data.profesorId) {
@@ -59,6 +66,13 @@ export async function acceptClassByStudent(recordId, data) {
     } catch (err) {
       console.error(err);
     }
+  }
+  try {
+    if (data.claseId) {
+      await updateDoc(doc(db, 'clases', data.claseId), { estado: 'profesor_asignado' });
+    }
+  } catch (err) {
+    console.error(err);
   }
   await addDoc(collection(db, 'clases_union'), {
     claseId: data.claseId,


### PR DESCRIPTION
## Summary
- show tutor confirmation step in progress bar
- map new state transitions for student class requests
- sync Firebase class documents with tutor acceptance and final assignment

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68aaf414aefc832bb45790d721f3a7c3