### PR TITLE
Separar tabs de clases y ofertas en panel profesor

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -109,7 +109,8 @@ function AppContent() {
               <Route path="/profesor"             element={<PanelProfesor />} />
               <Route path="/profesor/ofertas"     element={<Ofertas />} />
               <Route path="/profesor/calendario"  element={<CalendarioP />} />
-              <Route path="/profesor/mis-clases"  element={<ClasesProfesor />} />
+              <Route path="/profesor/mis-clases"  element={<ClasesProfesor only="clases" />} />
+              <Route path="/profesor/mis-ofertas" element={<ClasesProfesor only="ofertas" />} />
               <Route path="/profesor/mis-alumnos" element={<MisAlumnos />} />
             </Route>
 

--- a/src/screens/profesor/PanelProfesor.jsx
+++ b/src/screens/profesor/PanelProfesor.jsx
@@ -85,8 +85,10 @@ export default function PanelProfesor() {
     switch(view) {
       case 'ofertas':
         return <Ofertas />;
-      case 'clases':
-        return <ClasesProfesor />;
+      case 'misClases':
+        return <ClasesProfesor only="clases" />;
+      case 'misOfertas':
+        return <ClasesProfesor only="ofertas" />;
       case 'calendario':
         return <CalendarioProfesor />;
       case 'misAlumnos':
@@ -111,10 +113,18 @@ export default function PanelProfesor() {
           </MenuItem>
           <MenuItem>
             <Button
-              active={view === 'clases'}
-              onClick={() => setView('clases')}
+              active={view === 'misClases'}
+              onClick={() => setView('misClases')}
             >
-              Mis clases & Ofertas
+              Mis clases
+            </Button>
+          </MenuItem>
+          <MenuItem>
+            <Button
+              active={view === 'misOfertas'}
+              onClick={() => setView('misOfertas')}
+            >
+              Mis ofertas
             </Button>
           </MenuItem>
           <MenuItem>

--- a/src/screens/profesor/acciones/Clases.jsx
+++ b/src/screens/profesor/acciones/Clases.jsx
@@ -183,10 +183,10 @@ const ModalButton = styled.button`
       : `background: #f0f0f0; color: #333;`}
 `;
 
-export default function ClasesProfesor() {
+export default function ClasesProfesor({ only }) {
   const [searchParams, setSearchParams] = useSearchParams();
-  const initialView = searchParams.get('view') || 'clases';
-  const [view, setView] = useState(initialView);
+  const paramView = searchParams.get('view') || 'clases';
+  const [view, setView] = useState(only || paramView);
   const [clases, setClases] = useState([]);
   const [sortBy, setSortBy] = useState('fecha');
   const [editing, setEditing] = useState(null);
@@ -248,8 +248,10 @@ export default function ClasesProfesor() {
   }, []);
 
   useEffect(() => {
-    setSearchParams({ view });
-  }, [view, setSearchParams]);
+    if (!only) {
+      setSearchParams({ view });
+    }
+  }, [view, setSearchParams, only]);
 
 
   const sortedClases = useMemo(() => {
@@ -335,18 +337,22 @@ export default function ClasesProfesor() {
     return <LoadingScreen fullscreen />;
   }
 
+  const title = view === 'clases' ? 'Mis Clases' : 'Mis Ofertas';
+
   return (
     <Page>
       <Container>
-        <Title>Mis Clases & Ofertas</Title>
-        <Tabs
-          tabs={[
-            { label: 'Mis clases', value: 'clases' },
-            { label: 'Mis ofertas', value: 'ofertas' },
-          ]}
-          active={view}
-          onChange={setView}
-        />
+        <Title>{only ? title : 'Mis Clases & Ofertas'}</Title>
+        {!only && (
+          <Tabs
+            tabs={[
+              { label: 'Mis clases', value: 'clases' },
+              { label: 'Mis ofertas', value: 'ofertas' },
+            ]}
+            active={view}
+            onChange={setView}
+          />
+        )}
 
         {view === 'clases' ? (
           <>


### PR DESCRIPTION
## Summary
- Se añadió prop opcional en `ClasesProfesor` para reutilizar vista de clases u ofertas sin interruptor.
- Se actualizó `PanelProfesor` para incluir pestañas independientes de "Mis clases" y "Mis ofertas".
- Se ajustaron las rutas del profesor para las nuevas páginas separadas.

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ab182b7c2c832b822a25c147a8a731