### PR TITLE
Reordenar botones de confirmación

### DIFF
--- a/src/screens/SignUpProfesor.jsx
+++ b/src/screens/SignUpProfesor.jsx
@@ -642,11 +642,11 @@ export default function SignUpProfesor() {
           <Modal>
             <ModalText>¿Seguro que quieres volver atrás? Se perderán los datos ingresados.</ModalText>
             <ModalActions>
-              <ModalButton primary onClick={() => navigate('/alta')}>
-                Sí, más tarde
-              </ModalButton>
               <ModalButton onClick={() => setModalOpen(false)}>
                 No, permanezco
+              </ModalButton>
+              <ModalButton primary onClick={() => navigate('/alta')}>
+                Sí, más tarde
               </ModalButton>
             </ModalActions>
           </Modal>

--- a/src/screens/SignUpTutor.jsx
+++ b/src/screens/SignUpTutor.jsx
@@ -853,8 +853,8 @@ export default function SignUpTutor() {
           <Modal>
             <ModalText>¿Seguro que quieres volver atrás? Se perderán los datos ingresados.</ModalText>
             <ModalActions>
-              <ModalButton primary onClick={()=>navigate('/alta')}>Sí, más tarde</ModalButton>
               <ModalButton onClick={()=>setModalOpen(false)}>No, permanezco</ModalButton>
+              <ModalButton primary onClick={()=>navigate('/alta')}>Sí, más tarde</ModalButton>
             </ModalActions>
           </Modal>
         </Overlay>

--- a/src/screens/alumno/acciones/MisClases.jsx
+++ b/src/screens/alumno/acciones/MisClases.jsx
@@ -377,18 +377,18 @@ export default function MisClases() {
               </InfoGrid>
               {c.estado === 'pendiente' && (
                 <div>
-                  <AcceptButton
-                    onClick={() => acceptProposal(c)}
-                    disabled={processingIds.has(c.id)}
-                  >
-                    Aceptar
-                  </AcceptButton>{' '}
                   <RejectButton
                     onClick={() => rejectProposal(c)}
                     disabled={processingIds.has(c.id)}
                   >
                     Rechazar
-                  </RejectButton>
+                  </RejectButton>{' '}
+                  <AcceptButton
+                    onClick={() => acceptProposal(c)}
+                    disabled={processingIds.has(c.id)}
+                  >
+                    Aceptar
+                  </AcceptButton>
                 </div>
               )}
               {c.modificacionPendiente && (
@@ -396,18 +396,18 @@ export default function MisClases() {
                   <p style={{ marginTop: '0.5rem' }}>
                     El profesor propone modificar esta clase.
                   </p>
-                  <AcceptButton
-                    onClick={() => acceptModification(c)}
-                    disabled={processingIds.has(c.id)}
-                  >
-                    Aceptar cambio
-                  </AcceptButton>{' '}
                   <RejectButton
                     onClick={() => rejectModification(c)}
                     disabled={processingIds.has(c.id)}
                   >
                     Rechazar cambio
-                  </RejectButton>
+                  </RejectButton>{' '}
+                  <AcceptButton
+                    onClick={() => acceptModification(c)}
+                    disabled={processingIds.has(c.id)}
+                  >
+                    Aceptar cambio
+                  </AcceptButton>
                 </div>
               )}
             </Card>

--- a/src/screens/alumno/acciones/MisProfesores.jsx
+++ b/src/screens/alumno/acciones/MisProfesores.jsx
@@ -483,12 +483,12 @@ export default function MisProfesores() {
                         <strong>{formatDate(item.fecha)}</strong> a las <strong>{item.hora}</strong> ({item.duracion}h)
                         </div>
                         <div>Coste: €{(item.precioTotalPadres || 0).toFixed(2)}</div>
-                        <AcceptButton onClick={() => acceptProposal(item)}>
-                          Aceptar
-                        </AcceptButton>
                         <RejectButton onClick={() => rejectProposal(item)}>
                           Rechazar
                         </RejectButton>
+                        <AcceptButton onClick={() => acceptProposal(item)}>
+                          Aceptar
+                        </AcceptButton>
                       </Bubble>
                       <Timestamp mine={mine}>
                         {hh}:{mm}

--- a/src/screens/alumno/acciones/MisSolicitudes.jsx
+++ b/src/screens/alumno/acciones/MisSolicitudes.jsx
@@ -178,8 +178,8 @@ export default function MisSolicitudes() {
                   ?
                 </p>
                 <div>
-                  <AcceptButton onClick={() => acceptAssignment(p)} disabled={processingIds.has(p.id)}>Confirmar</AcceptButton>{' '}
-                  <RejectButton onClick={() => rejectAssignment(p)} disabled={processingIds.has(p.id)}>Rechazar</RejectButton>
+                  <RejectButton onClick={() => rejectAssignment(p)} disabled={processingIds.has(p.id)}>Rechazar</RejectButton>{' '}
+                  <AcceptButton onClick={() => acceptAssignment(p)} disabled={processingIds.has(p.id)}>Confirmar</AcceptButton>
                 </div>
               </Card>
             ))}

--- a/src/screens/profesor/acciones/MisOfertas.jsx
+++ b/src/screens/profesor/acciones/MisOfertas.jsx
@@ -151,8 +151,8 @@ export default function MisOfertas() {
             <Card key={o.id}>
               {alert && alert.estado === 'espera_profesor' && (
                 <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem', marginBottom: '0.5rem' }}>
-                  <Button onClick={() => handleAccept(alert)} disabled={processing.has(alert.id)}>Aceptar</Button>
                   <CancelButton onClick={() => handleCancel(alert)} disabled={processing.has(alert.id)}>Cancelar</CancelButton>
+                  <Button onClick={() => handleAccept(alert)} disabled={processing.has(alert.id)}>Aceptar</Button>
                 </div>
               )}
               <InfoGrid>


### PR DESCRIPTION
## Summary
- Ajustar el orden de los botones de confirmación para que aceptar quede a la derecha y cancelar/rechazar a la izquierda en pantallas de ofertas, clases, solicitudes y registro
- Unificar el orden de los botones en los modales de registro de profesor y tutor

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ab1a283a98832b9daa4432f7096e0d