### PR TITLE
Add icons to tutor and professor panel tabs

### DIFF
--- a/src/screens/alumno/PanelTutor.jsx
+++ b/src/screens/alumno/PanelTutor.jsx
@@ -8,6 +8,14 @@ import { useNotification } from '../../NotificationContext';
 import ChildSelectorBubble from '../../components/ChildSelectorBubble';
 import AddChildModal from '../../components/AddChildModal';
 
+// icons
+import iconNuevaClase from '../../assets/icons/ofertas.png';
+import iconMisClases from '../../assets/icons/clases.png';
+import iconMisSolicitudes from '../../assets/icons/chat.png';
+import iconMisProfesores from '../../assets/icons/profesor.png';
+import iconCalendario from '../../assets/icons/calendario.png';
+import iconAlumnos from '../../assets/icons/alumnos.png';
+
 // importa tus pantallas “incrustadas”
 import NuevaClase    from './acciones/NuevaClase';
 import MisClases     from './acciones/MisClases';
@@ -57,6 +65,9 @@ const MenuItem = styled.li`
 `;
 
 const Button = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   width: 100%;
   padding: 0.75rem 1rem;
   background: ${({ active }) => active ? '#ccf3e5' : 'transparent'};
@@ -70,6 +81,11 @@ const Button = styled.button`
   &:hover {
     background: #f1f8f6;
   }
+`;
+
+const Icon = styled.img`
+  width: 20px;
+  height: 20px;
 `;
 
 
@@ -168,6 +184,7 @@ export default function PanelTutor() {
               active={view === 'nueva-clase'}
               onClick={() => handleMenuClick('nueva-clase')}
             >
+              <Icon src={iconNuevaClase} alt="Solicitar nuevo profesor" />
               Solicitar nuevo profesor
             </Button>
           </MenuItem>
@@ -176,6 +193,7 @@ export default function PanelTutor() {
               active={view === 'mis-clases'}
               onClick={() => handleMenuClick('mis-clases')}
             >
+              <Icon src={iconMisClases} alt="Mis Clases" />
               Mis Clases
             </Button>
           </MenuItem>
@@ -184,6 +202,7 @@ export default function PanelTutor() {
               active={view === 'mis-solicitudes'}
               onClick={() => handleMenuClick('mis-solicitudes')}
             >
+              <Icon src={iconMisSolicitudes} alt="Mis Solicitudes" />
               Mis Solicitudes
             </Button>
           </MenuItem>
@@ -192,6 +211,7 @@ export default function PanelTutor() {
               active={view === 'mis-profesores'}
               onClick={() => handleMenuClick('mis-profesores')}
             >
+              <Icon src={iconMisProfesores} alt="Mis profesores" />
               Mis profesores
             </Button>
           </MenuItem>
@@ -200,6 +220,7 @@ export default function PanelTutor() {
               active={view === 'calendario'}
               onClick={() => handleMenuClick('calendario')}
             >
+              <Icon src={iconCalendario} alt="Calendario" />
               Calendario
             </Button>
           </MenuItem>
@@ -209,6 +230,7 @@ export default function PanelTutor() {
                 active={view === 'mis-alumnos'}
                 onClick={() => handleMenuClick('mis-alumnos')}
               >
+                <Icon src={iconAlumnos} alt="Alumnos" />
                 Alumnos
               </Button>
             </MenuItem>

--- a/src/screens/profesor/PanelProfesor.jsx
+++ b/src/screens/profesor/PanelProfesor.jsx
@@ -8,6 +8,13 @@ import ClasesProfesor         from './acciones/Clases';
 import CalendarioProfesor     from './acciones/Calendario';
 import MisAlumnos             from './acciones/MisAlumnos';
 
+// icons
+import iconClasesDisponibles from '../../assets/icons/ofertas.png';
+import iconMisClases from '../../assets/icons/clases.png';
+import iconMisOfertas from '../../assets/icons/ofertas.png';
+import iconCalendario from '../../assets/icons/calendario.png';
+import iconMisAlumnos from '../../assets/icons/alumnos.png';
+
 const Container = styled.div`
   display: flex;
   min-height: 100vh;
@@ -47,6 +54,9 @@ const MenuItem = styled.li`
 `;
 
 const Button = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   width: 100%;
   padding: 0.75rem 1rem;
   background: ${({ active }) => active ? '#ccf3e5' : 'transparent'};
@@ -60,6 +70,11 @@ const Button = styled.button`
   &:hover {
     background: #f1f8f6;
   }
+`;
+
+const Icon = styled.img`
+  width: 20px;
+  height: 20px;
 `;
 
 const Content = styled.div`
@@ -108,6 +123,7 @@ export default function PanelProfesor() {
               active={view === 'ofertas'}
               onClick={() => setView('ofertas')}
             >
+              <Icon src={iconClasesDisponibles} alt="Clases disponibles" />
               Clases disponibles
             </Button>
           </MenuItem>
@@ -116,6 +132,7 @@ export default function PanelProfesor() {
               active={view === 'misClases'}
               onClick={() => setView('misClases')}
             >
+              <Icon src={iconMisClases} alt="Mis clases" />
               Mis clases
             </Button>
           </MenuItem>
@@ -124,6 +141,7 @@ export default function PanelProfesor() {
               active={view === 'misOfertas'}
               onClick={() => setView('misOfertas')}
             >
+              <Icon src={iconMisOfertas} alt="Mis ofertas" />
               Mis ofertas
             </Button>
           </MenuItem>
@@ -132,6 +150,7 @@ export default function PanelProfesor() {
               active={view === 'calendario'}
               onClick={() => setView('calendario')}
             >
+              <Icon src={iconCalendario} alt="Calendario" />
               Calendario
             </Button>
           </MenuItem>
@@ -140,6 +159,7 @@ export default function PanelProfesor() {
               active={view === 'misAlumnos'}
               onClick={() => setView('misAlumnos')}
             >
+              <Icon src={iconMisAlumnos} alt="Mis alumnos" />
               Mis alumnos
             </Button>
           </MenuItem>


### PR DESCRIPTION
## Summary
- Display menu icons in tutor panel for easier navigation
- Show matching icons in professor panel tabs with consistent styling

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ab1d756e34832ba30cbb39b425f8a0