### PR TITLE
Sync tab views with query parameters for tab navigation

### DIFF
--- a/src/screens/alumno/PanelTutor.jsx
+++ b/src/screens/alumno/PanelTutor.jsx
@@ -136,6 +136,14 @@ export default function PanelTutor() {
     }
   }, [selectedChild, userData, show]);
 
+  // Si la query ?tab cambia externamente, sincronizamos la vista
+  useEffect(() => {
+    const urlTab = searchParams.get('tab') || 'nueva-clase';
+    if (urlTab !== view) {
+      setView(urlTab);
+    }
+  }, [searchParams, view]);
+
   // Al cambiar de pestaña, subimos arriba y actualizamos la URL
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: 'smooth' });

--- a/src/screens/profesor/PanelProfesor.jsx
+++ b/src/screens/profesor/PanelProfesor.jsx
@@ -90,6 +90,14 @@ export default function PanelProfesor() {
   const initialTab = searchParams.get('tab') || 'ofertas';
   const [view, setView] = useState(initialTab);
 
+  // Actualiza la vista cuando la query ?tab cambia desde fuera
+  useEffect(() => {
+    const urlTab = searchParams.get('tab') || 'ofertas';
+    if (urlTab !== view) {
+      setView(urlTab);
+    }
+  }, [searchParams, view]);
+
   // Al cambiar de pestaña, subimos arriba y actualizamos la URL
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: 'smooth' });

--- a/src/screens/profesor/acciones/Clases.jsx
+++ b/src/screens/profesor/acciones/Clases.jsx
@@ -247,6 +247,16 @@ export default function ClasesProfesor({ only }) {
     return () => unsub();
   }, []);
 
+  // Sincroniza la vista si la query ?view cambia externamente
+  useEffect(() => {
+    if (!only) {
+      const urlView = searchParams.get('view') || 'clases';
+      if (urlView !== view) {
+        setView(urlView);
+      }
+    }
+  }, [searchParams, view, only]);
+
   useEffect(() => {
     if (!only) {
       setSearchParams({ view });


### PR DESCRIPTION
## Summary
- Sync tutor panel view state with `tab` query string changes
- Sync professor panel view state with `tab` query string changes
- Sync professor classes view state with `view` query string changes

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab21f646fc832ba6980a669a1a49be