### PR TITLE
Allow logged-in users to access footer pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -85,10 +85,10 @@ function AppContent() {
           <Route element={<Layout />}>
             <Route element={<RedirectLoggedIn />}>
               <Route path="/home"             element={<Home />} />
-              <Route path="/reserva-tu-clase" element={<ReservaClase />} />
-              <Route path="/ser-profesor"     element={<SerProfesor />} />
-              <Route path="/quienes-somos"    element={<QuienesSomos />} />
             </Route>
+            <Route path="/reserva-tu-clase" element={<ReservaClase />} />
+            <Route path="/ser-profesor"     element={<SerProfesor />} />
+            <Route path="/quienes-somos"    element={<QuienesSomos />} />
 
             {/* Ruta de perfil con parámetro userId */}
             <Route path="/perfil/:userId"       element={<Perfil />} />


### PR DESCRIPTION
## Summary
- Let logged-in users open footer links like reserva, ser profesor, and quienes somos

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ab23462e34832b9d51a326ee814480