### PR TITLE
Display correct student avatars to professors

### DIFF
--- a/src/screens/profesor/acciones/MisAlumnos.jsx
+++ b/src/screens/profesor/acciones/MisAlumnos.jsx
@@ -356,7 +356,15 @@ export default function MisAlumnos() {
           let photoURL = '';
           try {
             const usnap = await getDoc(doc(db, 'usuarios', data.alumnoId));
-            photoURL = usnap.exists() ? usnap.data().photoURL || '' : '';
+            if (usnap.exists()) {
+              const udata = usnap.data();
+              if (data.hijoId && Array.isArray(udata.alumnos)) {
+                const hijo = udata.alumnos.find(h => h.id === data.hijoId);
+                photoURL = hijo?.photoURL || '';
+              } else {
+                photoURL = udata.photoURL || '';
+              }
+            }
           } catch (err) {
             console.error(err);
           }


### PR DESCRIPTION
## Summary
- Load each student's avatar in Mis alumnos using `hijoId`
- Ensure professors see the specific avatar for each student

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ab27049250832bb1e1b20475039b55