### PR TITLE
Auto-fill year 4 when career is completed

### DIFF
--- a/src/components/CompleteTeacherProfileModal.jsx
+++ b/src/components/CompleteTeacherProfileModal.jsx
@@ -192,7 +192,11 @@ export default function CompleteTeacherProfileModal({ open, onClose, userData })
             <input className="form-control"
               type="checkbox"
               checked={finished}
-              onChange={e => setFinished(e.target.checked)}
+              onChange={e => {
+                const checked = e.target.checked;
+                setFinished(checked);
+                setStudyTime(checked ? '4' : '');
+              }}
             />{' '}Carrera finalizada
           </label>
         </Field>

--- a/src/screens/shared/Perfil.jsx
+++ b/src/screens/shared/Perfil.jsx
@@ -408,7 +408,7 @@ export default function Perfil() {
         setFormData({
           ciudad: data.ciudad || '',
           studies: data.studies || '',
-          studyTime: data.studyTime || '',
+          studyTime: data.careerFinished ? '4' : data.studyTime || '',
           careerFinished: data.careerFinished || false,
           job: data.job || '',
           status: data.status || '',
@@ -652,15 +652,21 @@ export default function Perfil() {
                           setFormData({ ...formData, studyTime: e.target.value })
                         }
                         placeholder="Tiempo estudiando"
+                        disabled={formData.careerFinished}
                       />
                       <label style={{ display: 'block', marginTop: '0.5rem' }}>
                         <input
                           className="form-control"
                           type="checkbox"
                           checked={formData.careerFinished}
-                          onChange={e =>
-                            setFormData({ ...formData, careerFinished: e.target.checked })
-                          }
+                          onChange={e => {
+                            const checked = e.target.checked;
+                            setFormData({
+                              ...formData,
+                              careerFinished: checked,
+                              studyTime: checked ? '4' : ''
+                            });
+                          }}
                         />{' '}Carrera finalizada
                       </label>
                       <InlineInput


### PR DESCRIPTION
## Summary
- Auto-set study year to 4 and clear it when 'Carrera finalizada' is toggled in tutor forms
- Disable manual year input when career is finished
- Initialize study year to 4 when profile indicates finished career

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68ab2b4134f0832ba1a6205450a4a806