### PR TITLE
Handle class cancellation by tutor or professor

### DIFF
--- a/src/screens/alumno/acciones/MisSolicitudes.jsx
+++ b/src/screens/alumno/acciones/MisSolicitudes.jsx
@@ -155,7 +155,7 @@ export default function MisSolicitudes() {
     if (processingIds.has(rec.id)) return;
     setProcessingIds(prev => new Set(prev).add(rec.id));
     try {
-      await rejectPendingClass(rec.id);
+      await rejectPendingClass(rec, 'tutor');
       setPendingAssignments(pa => pa.filter(r => r.id !== rec.id));
     } finally {
       setProcessingIds(prev => { const s = new Set(prev); s.delete(rec.id); return s; });

--- a/src/screens/profesor/acciones/MisOfertas.jsx
+++ b/src/screens/profesor/acciones/MisOfertas.jsx
@@ -129,7 +129,7 @@ export default function MisOfertas() {
     if (processing.has(rec.id)) return;
     setProcessing(prev => new Set(prev).add(rec.id));
     try {
-      await rejectPendingClass(rec.id);
+      await rejectPendingClass(rec, 'profesor');
       setAssignments(as => as.filter(a => a.id !== rec.id));
       setOffers(os => os.map(o => o.id === rec.offerId ? { ...o, estado: 'cancelada' } : o));
     } finally {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -135,3 +135,12 @@ export async function liquidarBalance(userId, role, email) {
   });
   return handleResponse(res);
 }
+
+export async function cancelOffer({ offerId, pujaId, role }) {
+  const res = await fetch(`${API_URL}/cancel-offer`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ offerId, pujaId, role }),
+  });
+  return handleResponse(res);
+}


### PR DESCRIPTION
## Summary
- Add `/cancel-offer` endpoint to remove offers and bids, reset status, and notify both parties
- Call new endpoint and clean up Firestore when tutor or professor cancels a pending assignment
- Expose `cancelOffer` API helper and update UI flows to pass record and role

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ab2d6c86ec832b9f64b0cf20acb4d1