### PR TITLE
Evitar duplicados en listas de profesores y alumnos

### DIFF
--- a/src/ChildContext.js
+++ b/src/ChildContext.js
@@ -10,7 +10,16 @@ export const ChildProvider = ({ children }) => {
 
   useEffect(() => {
     if (userData?.rol === 'tutor') {
-      const alumnos = (userData.alumnos || []).filter(h => !h.disabled);
+      const raw = userData.alumnos || [];
+      // Asegura que no haya alumnos repetidos por id
+      const alumnos = [];
+      const seen = new Set();
+      for (const h of raw) {
+        if (!h.disabled && !seen.has(h.id)) {
+          alumnos.push(h);
+          seen.add(h.id);
+        }
+      }
       setChildList(alumnos);
       setSelectedChild(prev => {
         if (prev && alumnos.some(h => h.id === prev.id)) {

--- a/src/screens/alumno/acciones/MisProfesores.jsx
+++ b/src/screens/alumno/acciones/MisProfesores.jsx
@@ -253,7 +253,16 @@ export default function MisProfesores() {
           return { id: d.id, ...data, profesorPhotoURL: photoURL };
         })
       );
-      setUnions(items);
+      // Elimina profesores duplicados para que solo aparezcan una vez
+      const unique = [];
+      const seen = new Set();
+      for (const item of items) {
+        if (!seen.has(item.profesorId)) {
+          unique.push(item);
+          seen.add(item.profesorId);
+        }
+      }
+      setUnions(unique);
       setLoading(false);
     }
     fetchUnions();


### PR DESCRIPTION
## Resumen
- Filtrado de alumnos repetidos por id en `ChildContext` para mantener lista única.
- Eliminación de profesores duplicados en `MisProfesores` mostrando solo uno por docente.

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ab31049cb8832baa03c61a63d0f5ee