### PR TITLE
Fix student name display in professor view

### DIFF
--- a/src/screens/profesor/acciones/Clases.jsx
+++ b/src/screens/profesor/acciones/Clases.jsx
@@ -207,14 +207,12 @@ export default function ClasesProfesor({ only }) {
       const promises = snap.docs.map(async docu => {
         const union = docu.data();
         let alumnoFoto = '';
-        let alumnoApellido = '';
         let curso = '';
         try {
           const alumSnap = await getDoc(doc(db, 'usuarios', union.alumnoId));
           if (alumSnap.exists()) {
             const d = alumSnap.data();
             alumnoFoto = d.photoURL || '';
-            alumnoApellido = d.apellido || '';
           }
           const classSnap = await getDoc(doc(db, 'clases', union.claseId));
           if (classSnap.exists()) curso = classSnap.data().curso || '';
@@ -232,7 +230,7 @@ export default function ClasesProfesor({ only }) {
               id: d.id,
               unionId: docu.id,
               alumnoId: union.alumnoId,
-              alumno: `${union.alumnoNombre} ${alumnoApellido}`.trim(),
+              alumno: union.alumnoNombre,
               alumnoFoto,
               curso,
               ...data


### PR DESCRIPTION
## Summary
- show only student's first name in professor's class list

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ab3cddb08c832baa77eeaa989241f5