### PR TITLE
Improve spacing between profile edit buttons

### DIFF
--- a/src/screens/shared/Perfil.jsx
+++ b/src/screens/shared/Perfil.jsx
@@ -169,6 +169,7 @@ const EditButton = styled.button`
   padding: 0.5rem 1rem;
   cursor: pointer;
   margin-top: 0.5rem;
+  margin-right: 0.5rem;
   &:hover {
     background: #005047;
   }


### PR DESCRIPTION
## Summary
- add right margin to profile editing buttons so they aren't glued together

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab3de1704c832ba2d439cdffa3755a