### PR TITLE
Center card action buttons

### DIFF
--- a/src/components/CardActions.jsx
+++ b/src/components/CardActions.jsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+const CardActions = styled.div`
+  margin-top: auto;
+  padding-top: 0.5rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+`;
+
+export default CardActions;

--- a/src/screens/alumno/acciones/MisClases.jsx
+++ b/src/screens/alumno/acciones/MisClases.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import styled, { keyframes } from 'styled-components';
 import { useChild } from '../../../ChildContext';
 import Card from '../../../components/CommonCard';
+import CardActions from '../../../components/CardActions';
 import InfoGrid from '../../../components/InfoGrid';
 import { auth, db } from '../../../firebase/firebaseConfig';
 import {
@@ -376,39 +377,41 @@ export default function MisClases() {
                 </div>
               </InfoGrid>
               {c.estado === 'pendiente' && (
-                <div>
+                <CardActions>
                   <RejectButton
                     onClick={() => rejectProposal(c)}
                     disabled={processingIds.has(c.id)}
                   >
                     Rechazar
-                  </RejectButton>{' '}
+                  </RejectButton>
                   <AcceptButton
                     onClick={() => acceptProposal(c)}
                     disabled={processingIds.has(c.id)}
                   >
                     Aceptar
                   </AcceptButton>
-                </div>
+                </CardActions>
               )}
               {c.modificacionPendiente && (
-                <div>
+                <>
                   <p style={{ marginTop: '0.5rem' }}>
                     El profesor propone modificar esta clase.
                   </p>
-                  <RejectButton
-                    onClick={() => rejectModification(c)}
-                    disabled={processingIds.has(c.id)}
-                  >
-                    Rechazar cambio
-                  </RejectButton>{' '}
-                  <AcceptButton
-                    onClick={() => acceptModification(c)}
-                    disabled={processingIds.has(c.id)}
-                  >
-                    Aceptar cambio
-                  </AcceptButton>
-                </div>
+                  <CardActions>
+                    <RejectButton
+                      onClick={() => rejectModification(c)}
+                      disabled={processingIds.has(c.id)}
+                    >
+                      Rechazar cambio
+                    </RejectButton>
+                    <AcceptButton
+                      onClick={() => acceptModification(c)}
+                      disabled={processingIds.has(c.id)}
+                    >
+                      Aceptar cambio
+                    </AcceptButton>
+                  </CardActions>
+                </>
               )}
             </Card>
           ))

--- a/src/screens/alumno/acciones/MisSolicitudes.jsx
+++ b/src/screens/alumno/acciones/MisSolicitudes.jsx
@@ -4,6 +4,7 @@ import styled, { keyframes } from 'styled-components';
 import { Link } from 'react-router-dom';
 import { useChild } from '../../../ChildContext';
 import Card from '../../../components/CommonCard';
+import CardActions from '../../../components/CardActions';
 import InfoGrid from '../../../components/InfoGrid';
 import ProgressBar from '../../../components/ProgressBar';
 import { auth, db } from '../../../firebase/firebaseConfig';
@@ -177,10 +178,10 @@ export default function MisSolicitudes() {
                   <Link to={`/perfil/${p.profesorId}`}>{p.profesorNombre}</Link>
                   ?
                 </p>
-                <div>
-                  <RejectButton onClick={() => rejectAssignment(p)} disabled={processingIds.has(p.id)}>Rechazar</RejectButton>{' '}
+                <CardActions>
+                  <RejectButton onClick={() => rejectAssignment(p)} disabled={processingIds.has(p.id)}>Rechazar</RejectButton>
                   <AcceptButton onClick={() => acceptAssignment(p)} disabled={processingIds.has(p.id)}>Confirmar</AcceptButton>
-                </div>
+                </CardActions>
               </Card>
             ))}
             {solicitudes.map(s => {

--- a/src/screens/profesor/acciones/MisOfertas.jsx
+++ b/src/screens/profesor/acciones/MisOfertas.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import styled from 'styled-components';
 import Card from '../../../components/CommonCard';
+import CardActions from '../../../components/CardActions';
 import InfoGrid from '../../../components/InfoGrid';
 import LoadingScreen from '../../../components/LoadingScreen';
 import { auth, db } from '../../../firebase/firebaseConfig';
@@ -149,18 +150,18 @@ export default function MisOfertas() {
           const { text, color } = statusInfo(o, alert);
           return (
             <Card key={o.id}>
-              {alert && alert.estado === 'espera_profesor' && (
-                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem', marginBottom: '0.5rem' }}>
-                  <CancelButton onClick={() => handleCancel(alert)} disabled={processing.has(alert.id)}>Cancelar</CancelButton>
-                  <Button onClick={() => handleAccept(alert)} disabled={processing.has(alert.id)}>Aceptar</Button>
-                </div>
-              )}
               <InfoGrid>
                 <div><strong>Alumno:</strong> {o.alumnoNombre || alert?.alumnoNombre || '-'}</div>
                 <div><strong>Asignaturas:</strong> {o.asignaturas ? o.asignaturas.join(', ') : o.asignatura || alert?.classInfo?.asignaturas?.join(', ') || alert?.classInfo?.asignatura}</div>
                 {o.precio && (<div><strong>Precio ofertado:</strong> €{o.precio}</div>)}
                 <div><strong>Estado:</strong> <StatusText color={color}>{text}</StatusText></div>
               </InfoGrid>
+              {alert && alert.estado === 'espera_profesor' && (
+                <CardActions>
+                  <CancelButton onClick={() => handleCancel(alert)} disabled={processing.has(alert.id)}>Cancelar</CancelButton>
+                  <Button onClick={() => handleAccept(alert)} disabled={processing.has(alert.id)}>Aceptar</Button>
+                </CardActions>
+              )}
             </Card>
           );
         })


### PR DESCRIPTION
## Summary
- ensure card accept/cancel controls sit at the bottom
- consolidate button layout with reusable CardActions component

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68ab3e042260832ba2433f63d2abcfff