### PR TITLE
Center accept/cancel buttons at bottom of cards

### DIFF
--- a/src/screens/alumno/acciones/MisClases.jsx
+++ b/src/screens/alumno/acciones/MisClases.jsx
@@ -93,8 +93,6 @@ const Value = styled.span`
 `;
 
 const AcceptButton = styled.button`
-  margin-top: 0.5rem;
-  margin-right: 0.5rem;
   background: #006d5b;
   color: #fff;
   border: none;
@@ -112,8 +110,6 @@ const AcceptButton = styled.button`
 `;
 
 const RejectButton = styled.button`
-  margin-top: 0.5rem;
-  margin-right: 0.5rem;
   background: #f56565;
   color: #fff;
   border: none;
@@ -128,6 +124,13 @@ const RejectButton = styled.button`
     opacity: 0.6;
     cursor: not-allowed;
   }
+`;
+
+const CardActions = styled.div`
+  margin-top: auto;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
 `;
 
 export default function MisClases() {
@@ -326,20 +329,20 @@ export default function MisClases() {
                 </div>
               </InfoGrid>
               {c.estado === 'pendiente' && (
-                <div>
+                <CardActions>
                   <RejectButton
                     onClick={() => rejectProposal(c)}
                     disabled={processingIds.has(c.id)}
                   >
                     Rechazar
-                  </RejectButton>{' '}
+                  </RejectButton>
                   <AcceptButton
                     onClick={() => acceptProposal(c)}
                     disabled={processingIds.has(c.id)}
                   >
                     Aceptar
                   </AcceptButton>
-                </div>
+                </CardActions>
               )}
             </Card>
           ))

--- a/src/screens/alumno/acciones/MisSolicitudes.jsx
+++ b/src/screens/alumno/acciones/MisSolicitudes.jsx
@@ -50,8 +50,6 @@ const Value = styled.span`
 `;
 
 const AcceptButton = styled.button`
-  margin-top: 0.5rem;
-  margin-right: 0.5rem;
   background: #006d5b;
   color: #fff;
   border: none;
@@ -69,8 +67,6 @@ const AcceptButton = styled.button`
 `;
 
 const RejectButton = styled.button`
-  margin-top: 0.5rem;
-  margin-right: 0.5rem;
   background: #f56565;
   color: #fff;
   border: none;
@@ -85,6 +81,13 @@ const RejectButton = styled.button`
     opacity: 0.6;
     cursor: not-allowed;
   }
+`;
+
+const CardActions = styled.div`
+  margin-top: auto;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
 `;
 
 const getProgressData = s => {
@@ -179,10 +182,10 @@ export default function MisSolicitudes() {
                   <Link to={`/perfil/${p.profesorId}`}>{p.profesorNombre}</Link>
                   ?
                 </p>
-                <div>
-                  <RejectButton onClick={() => rejectAssignment(p)} disabled={processingIds.has(p.id)}>Rechazar</RejectButton>{' '}
+                <CardActions>
+                  <RejectButton onClick={() => rejectAssignment(p)} disabled={processingIds.has(p.id)}>Rechazar</RejectButton>
                   <AcceptButton onClick={() => acceptAssignment(p)} disabled={processingIds.has(p.id)}>Confirmar</AcceptButton>
-                </div>
+                </CardActions>
               </Card>
             ))}
             {solicitudes.map(s => {

--- a/src/screens/profesor/acciones/Clases.jsx
+++ b/src/screens/profesor/acciones/Clases.jsx
@@ -97,7 +97,6 @@ const Value = styled.span`
 `;
 
 const CancelButton = styled.button`
-  margin: 0.5rem auto 0;
   background: #e53e3e;
   color: #fff;
   border: none;
@@ -105,11 +104,16 @@ const CancelButton = styled.button`
   padding: 0.25rem 0.8rem;
   font-size: 0.85rem;
   cursor: pointer;
-  display: block;
-  width: fit-content;
   &:hover {
     background: #c53030;
   }
+`;
+
+const CardActions = styled.div`
+  margin-top: auto;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
 `;
 
 
@@ -277,9 +281,11 @@ export default function ClasesProfesor({ only }) {
                   </div>
                 </InfoGrid>
                 {c.estado === 'pendiente' && (
-                  <CancelButton onClick={() => cancelPending(c)}>
-                    Cancelar propuesta
-                  </CancelButton>
+                  <CardActions>
+                    <CancelButton onClick={() => cancelPending(c)}>
+                      Cancelar propuesta
+                    </CancelButton>
+                  </CardActions>
                 )}
               </Card>
             ))}

--- a/src/screens/profesor/acciones/MisOfertas.jsx
+++ b/src/screens/profesor/acciones/MisOfertas.jsx
@@ -13,7 +13,6 @@ const StatusText = styled.span`
 `;
 
 const Button = styled.button`
-  margin-top: 0.5rem;
   background: #006d5b;
   color: #fff;
   border: none;
@@ -35,6 +34,13 @@ const CancelButton = styled(Button)`
   &:hover:not(:disabled) {
     background: #c53030;
   }
+`;
+
+const CardActions = styled.div`
+  margin-top: auto;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
 `;
 
 export default function MisOfertas() {
@@ -149,18 +155,18 @@ export default function MisOfertas() {
           const { text, color } = statusInfo(o, alert);
           return (
             <Card key={o.id}>
-              {alert && alert.estado === 'espera_profesor' && (
-                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem', marginBottom: '0.5rem' }}>
-                  <CancelButton onClick={() => handleCancel(alert)} disabled={processing.has(alert.id)}>Cancelar</CancelButton>
-                  <Button onClick={() => handleAccept(alert)} disabled={processing.has(alert.id)}>Aceptar</Button>
-                </div>
-              )}
               <InfoGrid>
                 <div><strong>Alumno:</strong> {o.alumnoNombre || alert?.alumnoNombre || '-'}</div>
                 <div><strong>Asignaturas:</strong> {o.asignaturas ? o.asignaturas.join(', ') : o.asignatura || alert?.classInfo?.asignaturas?.join(', ') || alert?.classInfo?.asignatura}</div>
                 {o.precio && (<div><strong>Precio ofertado:</strong> €{o.precio}</div>)}
                 <div><strong>Estado:</strong> <StatusText color={color}>{text}</StatusText></div>
               </InfoGrid>
+              {alert && alert.estado === 'espera_profesor' && (
+                <CardActions>
+                  <CancelButton onClick={() => handleCancel(alert)} disabled={processing.has(alert.id)}>Cancelar</CancelButton>
+                  <Button onClick={() => handleAccept(alert)} disabled={processing.has(alert.id)}>Aceptar</Button>
+                </CardActions>
+              )}
             </Card>
           );
         })


### PR DESCRIPTION
## Summary
- Ensure accept/cancel buttons inside cards are centered at the bottom across views
- Add shared CardActions container for consistent button layout

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ab402ee7b4832ba4e0df2ddb48b93f