### PR TITLE
Redirect to role panels after authentication

### DIFF
--- a/src/screens/CompletarDatosGoogle.jsx
+++ b/src/screens/CompletarDatosGoogle.jsx
@@ -195,7 +195,8 @@ export default function CompletarDatosGoogle() {
         }
       }
       await setDoc(doc(db, 'usuarios', user.uid), data);
-      navigate('/home');
+      const target = rol === 'profesor' ? '/profesor' : rol === 'tutor' ? '/tutor' : '/home';
+      navigate(target);
     } catch (err) {
       console.error(err);
       show('Error al guardar datos', 'error');

--- a/src/screens/InicioSesion.jsx
+++ b/src/screens/InicioSesion.jsx
@@ -202,8 +202,13 @@ const InicioSesion = () => {
       return;
     }
     try {
-      await signInWithEmailAndPassword(auth, email, password);
-      navigate('/home');
+      const { user } = await signInWithEmailAndPassword(auth, email, password);
+      const snap = await getDoc(doc(db, 'usuarios', user.uid));
+      const rol = snap.exists() ? snap.data().rol : null;
+      if (rol === 'admin') navigate('/admin');
+      else if (rol === 'profesor') navigate('/profesor');
+      else if (rol === 'tutor') navigate('/tutor');
+      else navigate('/home');
     } catch (err) {
       setError(getAuthErrorMessage(err.code));
     }
@@ -219,7 +224,11 @@ const InicioSesion = () => {
       const snap = await getDoc(userRef);
       if (snap.exists()) {
         await updateDoc(userRef, { photoURL: user.photoURL });
-        navigate('/home');
+        const data = snap.data();
+        if (data?.rol === 'admin') navigate('/admin');
+        else if (data?.rol === 'profesor') navigate('/profesor');
+        else if (data?.rol === 'tutor') navigate('/tutor');
+        else navigate('/seleccion-rol');
       } else {
         await setDoc(userRef, { photoURL: user.photoURL }, { merge: true });
         navigate('/seleccion-rol');
@@ -234,8 +243,19 @@ const InicioSesion = () => {
     setError('');
     setLoading(true);
     try {
-      await signInWithPopup(auth, appleProvider);
-      navigate('/home');
+      const { user } = await signInWithPopup(auth, appleProvider);
+      const userRef = doc(db, 'usuarios', user.uid);
+      const snap = await getDoc(userRef);
+      if (snap.exists()) {
+        const data = snap.data();
+        if (data?.rol === 'admin') navigate('/admin');
+        else if (data?.rol === 'profesor') navigate('/profesor');
+        else if (data?.rol === 'tutor') navigate('/tutor');
+        else navigate('/seleccion-rol');
+      } else {
+        await setDoc(userRef, { photoURL: user.photoURL }, { merge: true });
+        navigate('/seleccion-rol');
+      }
     } catch (err) {
       setError(getAuthErrorMessage(err.code));
     }

--- a/src/screens/SignUpProfesor.jsx
+++ b/src/screens/SignUpProfesor.jsx
@@ -420,7 +420,7 @@ export default function SignUpProfesor() {
         await sendEmailVerification(auth.currentUser);
       }
       show('Profesor registrado con éxito', 'success');
-      navigate('/');
+      navigate('/profesor');
     } catch (err) {
       console.error(err);
       if (authUser) {

--- a/src/screens/SignUpTutor.jsx
+++ b/src/screens/SignUpTutor.jsx
@@ -478,7 +478,7 @@ export default function SignUpTutor() {
         await sendEmailVerification(auth.currentUser);
       }
       show('Tutor registrado con éxito', 'success');
-      navigate('/');
+      navigate('/tutor');
     } catch (err) {
       console.error(err);
       if (authUser) {


### PR DESCRIPTION
## Summary
- Navigate users to their specific panel after login, handling email/password, Google, and Apple sign-ins
- Redirect new tutor and professor accounts to their respective panels on signup
- Route Google sign-up flow to the correct panel after profile completion

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ab42e2c3f0832b8ce511b1800f513b