### PR TITLE
feat: improve admin payments screen and balances

### DIFF
--- a/node-server/index.js
+++ b/node-server/index.js
@@ -110,6 +110,69 @@ app.get('/pagos', async (_req, res) => {
     res.status(500).json({ error: 'Error fetching pagos' });
   }
 });
+
+app.get('/balances', async (req, res) => {
+  const role = req.query.role;
+  if (!role) return res.status(400).json({ error: 'role required' });
+  try {
+    const result = await db.query(
+      'SELECT user_id, saldo FROM student_project.saldo_usuario WHERE rol=$1 ORDER BY user_id',
+      [role]
+    );
+    res.json(result.rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Error fetching balances' });
+  }
+});
+
+app.post('/balances/:id/liquidar', async (req, res) => {
+  const { id } = req.params;
+  const { role, email } = req.body;
+  if (!role) return res.status(400).json({ error: 'role required' });
+  let client;
+  try {
+    client = await db.connect();
+    await client.query('BEGIN');
+    const result = await client.query(
+      'SELECT saldo FROM student_project.saldo_usuario WHERE user_id=$1 AND rol=$2',
+      [id, role]
+    );
+    const saldo = result.rows[0]?.saldo || 0;
+    await client.query(
+      'UPDATE student_project.saldo_usuario SET saldo=0 WHERE user_id=$1 AND rol=$2',
+      [id, role]
+    );
+    await client.query('COMMIT');
+
+    try {
+      const mail = email
+        ? email
+        : (await admin.firestore().collection('usuarios').doc(id).get()).data()?.email;
+      if (mail) {
+        const msg =
+          role === 'tutor'
+            ? `Debes ${saldo}€`
+            : `Se te va a ingresar en tu número de cuenta ${saldo}€`;
+        await transporter.sendMail({
+          to: mail,
+          subject: 'Liquidación de saldo',
+          text: msg,
+        });
+      }
+    } catch (e) {
+      console.error('Error sending mail', e);
+    }
+
+    res.json({ saldo });
+  } catch (err) {
+    if (client) await client.query('ROLLBACK');
+    console.error(err);
+    res.status(500).json({ error: 'Error liquidando balance' });
+  } finally {
+    if (client) client.release();
+  }
+});
 app.post('/transaccion', async (req, res) => {
   const {
     alumnoId,
@@ -198,6 +261,20 @@ app.post('/transaccion', async (req, res) => {
           id_profesor,
           id_alumno,
         ]
+      );
+      const totalTutor = Math.abs(montoTutor || 0);
+      const totalProfesor = Math.abs(montoProfesor || 0);
+      await client.query(
+        `INSERT INTO student_project.saldo_usuario AS su (user_id, rol, saldo)
+         VALUES ($1,'tutor',$2)
+         ON CONFLICT (user_id, rol) DO UPDATE SET saldo = su.saldo + EXCLUDED.saldo`,
+        [tutorId, -totalTutor]
+      );
+      await client.query(
+        `INSERT INTO student_project.saldo_usuario AS su (user_id, rol, saldo)
+         VALUES ($1,'profesor',$2)
+         ON CONFLICT (user_id, rol) DO UPDATE SET saldo = su.saldo + EXCLUDED.saldo`,
+        [profesorId, totalProfesor]
       );
     }
 

--- a/src/screens/admin/acciones/Pagos.jsx
+++ b/src/screens/admin/acciones/Pagos.jsx
@@ -1,79 +1,109 @@
 import React, { useEffect, useState } from 'react';
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
+import { PrimaryButton } from '../../../components/FormElements';
 import { fetchBalances, liquidarBalance } from '../../../utils/api';
 
+const fade = keyframes`from{opacity:0;transform:translateY(-10px);}to{opacity:1;transform:translateY(0);}`;
+
+const Page = styled.div`
+  background:#f7faf9;
+  min-height:100vh;
+  padding:2rem;
+`;
+
 const Container = styled.div`
-  max-width: 900px;
-  margin: 0 auto;
+  max-width:800px;
+  margin:auto;
+  animation:${fade} 0.4s ease-out;
+`;
+
+const Title = styled.h1`
+  text-align:center;
+  color:#034640;
+  margin-bottom:2rem;
 `;
 
 const Switch = styled.div`
-  margin-bottom: 1rem;
-  button {
-    margin-right: 0.5rem;
-    padding: 0.5rem 1rem;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
+  display:flex;
+  justify-content:center;
+  gap:1rem;
+  margin-bottom:1rem;
+  button{
+    padding:0.5rem 1rem;
+    border:none;
+    border-radius:6px;
+    cursor:pointer;
+    background:#e2e8f0;
+  }
+  .active{
+    background:${({theme})=>theme.colors.secondary};
+    color:${({theme})=>theme.colors.primary};
   }
 `;
 
 const Table = styled.table`
-  width: 100%;
-  border-collapse: collapse;
-  th, td {
-    border: 1px solid #ccc;
-    padding: 0.5rem;
-    text-align: left;
+  width:100%;
+  border-collapse:collapse;
+  th,td{
+    padding:0.5rem;
+    border:1px solid #e2e8f0;
+    text-align:left;
   }
 `;
 
-export default function Pagos() {
-  const [role, setRole] = useState('tutor');
-  const [rows, setRows] = useState([]);
+export default function Pagos(){
+  const [role,setRole]=useState('tutor');
+  const [rows,setRows]=useState([]);
 
-  useEffect(() => {
-    (async () => {
-      try {
-        const data = await fetchBalances(role);
+  useEffect(()=>{
+    (async()=>{
+      try{
+        const data=await fetchBalances(role);
         setRows(data);
-      } catch (e) {
+      }catch(e){
         console.error(e);
       }
     })();
-  }, [role]);
+  },[role]);
 
-  const handleLiquidar = async id => {
-    try {
-      const email = role === 'tutor' ? id : undefined;
+  const handleLiquidar=async(id)=>{
+    try{
+      const email = role==='tutor'?id:undefined;
       await liquidarBalance(id, role, email);
-      setRows(r => r.map(x => x.user_id === id ? { ...x, saldo: 0 } : x));
-    } catch (e) {
+      setRows(r=>r.map(x=>x.user_id===id?{...x,saldo:0}:x));
+    }catch(e){
       console.error(e);
     }
   };
 
-  return (
-    <Container>
-      <h2>Pagos</h2>
-      <Switch>
-        <button disabled={role==='tutor'} onClick={() => setRole('tutor')}>Tutores</button>
-        <button disabled={role==='profesor'} onClick={() => setRole('profesor')}>Profesores</button>
-      </Switch>
-      <Table>
-        <thead>
-          <tr><th>Usuario</th><th>Saldo (€)</th><th></th></tr>
-        </thead>
-        <tbody>
-          {rows.map(r => (
-            <tr key={r.user_id}>
-              <td>{r.user_id}</td>
-              <td>{r.saldo}</td>
-              <td><button onClick={() => handleLiquidar(r.user_id)}>Liquidar</button></td>
+  return(
+    <Page>
+      <Container>
+        <Title>Pagos</Title>
+        <Switch>
+          <button className={role==='tutor'?'active':''} onClick={()=>setRole('tutor')}>Tutores</button>
+          <button className={role==='profesor'?'active':''} onClick={()=>setRole('profesor')}>Profesores</button>
+        </Switch>
+        <Table>
+          <thead>
+            <tr>
+              <th>Usuario</th>
+              <th>Saldo (€)</th>
+              <th></th>
             </tr>
-          ))}
-        </tbody>
-      </Table>
-    </Container>
+          </thead>
+          <tbody>
+            {rows.map(r=> (
+              <tr key={r.user_id}>
+                <td>{r.user_id}</td>
+                <td>{r.saldo}</td>
+                <td><PrimaryButton onClick={()=>handleLiquidar(r.user_id)}>Mandar factura</PrimaryButton></td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      </Container>
+    </Page>
   );
 }
+


### PR DESCRIPTION
## Summary
- restyle admin payments screen to match app look and add invoice button
- track and settle user balances with new API endpoints
- update transaction workflow to keep saldo_usuario in sync
- fix saldo updates to disambiguate column usage

## Testing
- `npm test`
- `cd node-server && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab44aad79c832ba7b8f9bf824b2765