### PR TITLE
Restrict class registrations to past dates

### DIFF
--- a/node-server/index.js
+++ b/node-server/index.js
@@ -1082,8 +1082,7 @@ app.post('/notify-tutor-class', async (req, res) => {
   }
 
   const html = `
-      <p>Hola ${tutorName || 'tutor'}, el profesor ${teacherName || 'profesor'} ha añadido una clase para el alumno ${studentName || ''}.</p>
-      <p>Fecha y hora: ${classDate || ''} a las ${classTime || ''}.</p>
+      <p>Hola ${tutorName || 'tutor'}, el profesor ${teacherName || 'profesor'} ha registrado la clase del ${classDate || ''} a las ${classTime || ''} para el alumno ${studentName || ''}.</p>
       <p>Por favor, entra en el chat con el profesor para aceptarla.</p>
     `;
 

--- a/src/screens/alumno/acciones/MisClases.jsx
+++ b/src/screens/alumno/acciones/MisClases.jsx
@@ -208,7 +208,7 @@ export default function MisClases() {
       });
       await addDoc(collection(db, 'clases_union', clase.unionId, 'chats'), {
         senderId: clase.profesorId,
-        text: `He añadido una clase, ${formatDate(clase.fecha)} a las ${clase.hora}`,
+        text: `He añadido la clase del ${formatDate(clase.fecha)} a las ${clase.hora}`,
         createdAt: serverTimestamp()
       });
       await registerTransaction({

--- a/src/screens/alumno/acciones/MisProfesores.jsx
+++ b/src/screens/alumno/acciones/MisProfesores.jsx
@@ -350,17 +350,8 @@ export default function MisProfesores() {
       confirmadaEn: serverTimestamp(),
       pendienteAdmin: true
     });
-    // Mensaje persistente en el chat indicando la clase añadida
     const union = unions.find(u => u.id === chatUnionId);
     if (union) {
-      await addDoc(
-        collection(db, 'clases_union', chatUnionId, 'chats'),
-        {
-          senderId: union.profesorId,
-          text: `Clase confirmada de ${proposal.asignatura} el dia ${formatDate(proposal.fecha)}`,
-          createdAt: serverTimestamp()
-        }
-      );
       try {
         await registerTransaction({
           tutorId: auth.currentUser.uid,
@@ -455,18 +446,36 @@ export default function MisProfesores() {
             <MessageContainer ref={scrollRef}>
               {feedItems.map((item, idx) => {
                 if (item.type === 'proposal') {
-                  // La propuesta viene del profesor => mine = false para el alumno
-                  const mine = false;
                   const dateObj = item.createdAt?.toDate?.() || new Date();
                   const hh = String(dateObj.getHours()).padStart(2, '0');
                   const mm = String(dateObj.getMinutes()).padStart(2, '0');
+                  if (item.estado === 'aceptada') {
+                    const mine = true;
+                    return (
+                      <BubbleWrapper key={`p-${item.id}`} mine={mine}>
+                        <Sender>Tú</Sender>
+                        <Bubble mine={mine}>
+                          Has aceptado la clase del{' '}
+                          <strong>{formatDate(item.fecha)}</strong> a las{' '}
+                          <strong>{item.hora}</strong> de{' '}
+                          <strong>{item.asignatura}</strong> ({item.duracion}h)
+                        </Bubble>
+                        <Timestamp mine={mine}>
+                          {hh}:{mm}
+                        </Timestamp>
+                      </BubbleWrapper>
+                    );
+                  }
+                  const mine = false;
                   return (
                     <BubbleWrapper key={`p-${item.id}`} mine={mine}>
                       <Sender>{mine ? 'Tú (Propuesta)' : 'Profesor (Propuesta)'}</Sender>
                       <Bubble mine={mine}>
                         <div>
-                          El profesor ha añadido una clase de <strong> {item.asignatura}</strong> el{' '}
-                        <strong>{formatDate(item.fecha)}</strong> a las <strong>{item.hora}</strong> ({item.duracion}h)
+                          El profesor ha añadido la clase del{' '}
+                          <strong>{formatDate(item.fecha)}</strong> a las{' '}
+                          <strong>{item.hora}</strong> de{' '}
+                          <strong>{item.asignatura}</strong> ({item.duracion}h)
                         </div>
                         <div>Coste: €{(item.precioTotalPadres || 0).toFixed(2)}</div>
                         <RejectButton onClick={() => rejectProposal(item)}>

--- a/src/screens/profesor/acciones/MisAlumnos.jsx
+++ b/src/screens/profesor/acciones/MisAlumnos.jsx
@@ -469,6 +469,11 @@ export default function MisAlumnos() {
       show('Rellena todos los campos de la clase', 'error');
       return;
     }
+    const todayStr = new Date().toISOString().slice(0, 10);
+    if (fechaClase > todayStr) {
+      show('La fecha de la clase no puede ser posterior a hoy', 'error');
+      return;
+    }
     const durNum = parseFloat(duracion);
     // Obtener precios de la clase principal
     const claseSnap = await getDoc(doc(db, 'clases', selectedUnion.claseId));
@@ -599,12 +604,18 @@ export default function MisAlumnos() {
                       <Bubble mine={mine}>
                         <div>
                           {item.estado === 'aceptada'
-                            ? 'Clase confirmada'
-                            : 'Has añadido una clase de'}
-                        </div>
-                        <div>
-                          <strong>{item.asignatura}</strong> el{' '}
-                          <strong>{formatDate(item.fecha)}</strong> a las <strong>{item.hora}</strong> ({item.duracion}h)
+                            ? (
+                                <>El alumno ha aceptado la clase del{' '}
+                                <strong>{formatDate(item.fecha)}</strong> a las{' '}
+                                <strong>{item.hora}</strong> de{' '}
+                                <strong>{item.asignatura}</strong> ({item.duracion}h)</>
+                              )
+                            : (
+                                <>Has añadido la clase del{' '}
+                                <strong>{formatDate(item.fecha)}</strong> a las{' '}
+                                <strong>{item.hora}</strong> de{' '}
+                                <strong>{item.asignatura}</strong> ({item.duracion}h)</>
+                              )}
                         </div>
                         {item.estado === 'pendiente' && (
                           <CancelButton onClick={() => cancelProposal(item)}>
@@ -665,6 +676,7 @@ export default function MisAlumnos() {
               <InputDate
                 type="date"
                 value={fechaClase}
+                max={new Date().toISOString().slice(0, 10)}
                 onChange={e => setFechaClase(e.target.value)}
               />
               <Label>Hora:</Label>


### PR DESCRIPTION
## Summary
- Prevent teachers from registering classes dated after today
- Use past-tense notifications for class addition and acceptance across teacher and student views
- Update tutor email to reference recorded classes in the past

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ab7aa78f44832ba23a94cdf0fddde6