### PR TITLE
Fix saldo query ambiguity and redesign admin payments page

### DIFF
--- a/node-server/index.js
+++ b/node-server/index.js
@@ -265,15 +265,17 @@ app.post('/transaccion', async (req, res) => {
       const totalTutor = Math.abs(montoTutor || 0);
       const totalProfesor = Math.abs(montoProfesor || 0);
       await client.query(
-        `INSERT INTO student_project.saldo_usuario AS su (user_id, rol, saldo)
+        `INSERT INTO student_project.saldo_usuario (user_id, rol, saldo)
          VALUES ($1,'tutor',$2)
-         ON CONFLICT (user_id, rol) DO UPDATE SET saldo = su.saldo + EXCLUDED.saldo`,
+         ON CONFLICT (user_id, rol) DO UPDATE
+         SET saldo = student_project.saldo_usuario.saldo + EXCLUDED.saldo`,
         [tutorId, -totalTutor]
       );
       await client.query(
-        `INSERT INTO student_project.saldo_usuario AS su (user_id, rol, saldo)
+        `INSERT INTO student_project.saldo_usuario (user_id, rol, saldo)
          VALUES ($1,'profesor',$2)
-         ON CONFLICT (user_id, rol) DO UPDATE SET saldo = su.saldo + EXCLUDED.saldo`,
+         ON CONFLICT (user_id, rol) DO UPDATE
+         SET saldo = student_project.saldo_usuario.saldo + EXCLUDED.saldo`,
         [profesorId, totalProfesor]
       );
     }

--- a/src/screens/admin/acciones/Pagos.jsx
+++ b/src/screens/admin/acciones/Pagos.jsx
@@ -13,7 +13,7 @@ const Page = styled.div`
 `;
 
 const Container = styled.div`
-  max-width:800px;
+  max-width:900px;
   margin:auto;
   animation:${fade} 0.4s ease-out;
 `;
@@ -21,7 +21,8 @@ const Container = styled.div`
 const Title = styled.h1`
   text-align:center;
   color:#034640;
-  margin-bottom:2rem;
+  margin-bottom:1.5rem;
+  font-size:2.5rem;
 `;
 
 const Counter = styled.p`
@@ -31,31 +32,25 @@ const Counter = styled.p`
   margin-bottom:1rem;
   font-weight:500;
 `;
-
-const List = styled.ul`
-  list-style:none;
-  padding:0;
-  margin:0;
-`;
-
-const Item = styled.li`
-  display:flex;
-  justify-content:space-between;
-  align-items:center;
+const Table = styled.table`
+  width:100%;
+  border-collapse:collapse;
   background:#fff;
   border-radius:8px;
-  padding:0.75rem 1rem;
-  margin-bottom:0.75rem;
+  overflow:hidden;
   box-shadow:0 4px 12px rgba(0,0,0,0.05);
 `;
 
-const User = styled.span`
+const Th = styled.th`
+  text-align:left;
+  padding:0.75rem 1rem;
+  background:#e6f2ef;
   color:#034640;
-  font-weight:500;
 `;
 
-const Amount = styled.span`
-  margin-right:1rem;
+const Td = styled.td`
+  padding:0.75rem 1rem;
+  border-top:1px solid #e2e8f0;
 `;
 
 export default function Pagos(){
@@ -100,15 +95,28 @@ export default function Pagos(){
           onChange={val=>setRole(val==='left'?'tutor':'profesor')}
         />
         <Counter>Total saldo: {total}€</Counter>
-        <List>
-          {rows.map(r=> (
-            <Item key={r.user_id}>
-              <User>{r.user_id}</User>
-              <Amount>{r.saldo}€</Amount>
-              <PrimaryButton onClick={()=>handleLiquidar(r.user_id)}>Mandar factura</PrimaryButton>
-            </Item>
-          ))}
-        </List>
+        <Table>
+          <thead>
+            <tr>
+              <Th>Usuario</Th>
+              <Th>Saldo</Th>
+              <Th></Th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(r => (
+              <tr key={r.user_id}>
+                <Td>{r.user_id}</Td>
+                <Td>{r.saldo}€</Td>
+                <Td>
+                  <PrimaryButton onClick={() => handleLiquidar(r.user_id)}>
+                    Mandar factura
+                  </PrimaryButton>
+                </Td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
       </Container>
     </Page>
   );


### PR DESCRIPTION
## Summary
- Avoid ambiguous `saldo` references when updating user balances
- Restyle admin payments page to use a unified table layout and show totals

## Testing
- `npm test`
- `cd node-server && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab8c9a9480832b99e83c384b15567d