### PR TITLE
Fix saldo query ambiguity and redesign admin payments page

### DIFF
--- a/src/screens/admin/acciones/Pagos.jsx
+++ b/src/screens/admin/acciones/Pagos.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import styled, { keyframes } from 'styled-components';
-import ToggleSwitch from '../../../components/ToggleSwitch';
 import { PrimaryButton } from '../../../components/FormElements';
 import { fetchBalances, liquidarBalance } from '../../../utils/api';
 
@@ -13,7 +12,7 @@ const Page = styled.div`
 `;
 
 const Container = styled.div`
-  max-width:800px;
+  max-width:900px;
   margin:auto;
   animation:${fade} 0.4s ease-out;
 `;
@@ -21,7 +20,8 @@ const Container = styled.div`
 const Title = styled.h1`
   text-align:center;
   color:#034640;
-  margin-bottom:2rem;
+  margin-bottom:1.5rem;
+  font-size:2.5rem;
 `;
 
 const Counter = styled.p`
@@ -31,56 +31,56 @@ const Counter = styled.p`
   margin-bottom:1rem;
   font-weight:500;
 `;
-
-const List = styled.ul`
-  list-style:none;
-  padding:0;
-  margin:0;
-`;
-
-const Item = styled.li`
-  display:flex;
-  justify-content:space-between;
-  align-items:center;
+const Table = styled.table`
+  width:100%;
+  border-collapse:collapse;
   background:#fff;
   border-radius:8px;
-  padding:0.75rem 1rem;
-  margin-bottom:0.75rem;
+  overflow:hidden;
   box-shadow:0 4px 12px rgba(0,0,0,0.05);
 `;
 
-const User = styled.span`
+const Th = styled.th`
+  text-align:left;
+  padding:0.75rem 1rem;
+  background:#e6f2ef;
   color:#034640;
-  font-weight:500;
 `;
 
-const Amount = styled.span`
-  margin-right:1rem;
+const Td = styled.td`
+  padding:0.75rem 1rem;
+  border-top:1px solid #e2e8f0;
 `;
 
 export default function Pagos(){
-  const [role,setRole]=useState('tutor');
   const [rows,setRows]=useState([]);
   const [total,setTotal]=useState(0);
 
   useEffect(()=>{
     (async()=>{
       try{
-        const data=await fetchBalances(role);
-        setRows(data);
-        setTotal(data.reduce((a,b)=>a+Number(b.saldo||0),0));
+        const [tutores, profesores] = await Promise.all([
+          fetchBalances('tutor'),
+          fetchBalances('profesor')
+        ]);
+        const combined=[
+          ...tutores.map(r=>({...r, rol:'tutor'})),
+          ...profesores.map(r=>({...r, rol:'profesor'}))
+        ];
+        setRows(combined);
+        setTotal(combined.reduce((a,b)=>a+Number(b.saldo||0),0));
       }catch(e){
         console.error(e);
       }
     })();
-  },[role]);
+  },[]);
 
-  const handleLiquidar=async(id)=>{
+  const handleLiquidar=async(id, rol)=>{
     try{
-      const email = role==='tutor'?id:undefined;
-      await liquidarBalance(id, role, email);
+      const email = rol==='tutor'?id:undefined;
+      await liquidarBalance(id, rol, email);
       setRows(r=>{
-        const updated=r.map(x=>x.user_id===id?{...x,saldo:0}:x);
+        const updated=r.map(x=>x.user_id===id && x.rol===rol?{...x,saldo:0}:x);
         setTotal(updated.reduce((a,b)=>a+Number(b.saldo||0),0));
         return updated;
       });
@@ -93,22 +93,31 @@ export default function Pagos(){
     <Page>
       <Container>
         <Title>Pagos</Title>
-        <ToggleSwitch
-          leftLabel="Tutores"
-          rightLabel="Profesores"
-          value={role==='tutor'?'left':'right'}
-          onChange={val=>setRole(val==='left'?'tutor':'profesor')}
-        />
         <Counter>Total saldo: {total}€</Counter>
-        <List>
-          {rows.map(r=> (
-            <Item key={r.user_id}>
-              <User>{r.user_id}</User>
-              <Amount>{r.saldo}€</Amount>
-              <PrimaryButton onClick={()=>handleLiquidar(r.user_id)}>Mandar factura</PrimaryButton>
-            </Item>
-          ))}
-        </List>
+        <Table>
+          <thead>
+            <tr>
+              <Th>Usuario</Th>
+              <Th>Rol</Th>
+              <Th>Saldo</Th>
+              <Th></Th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(r => (
+              <tr key={`${r.user_id}-${r.rol}`}>
+                <Td>{r.user_id}</Td>
+                <Td>{r.rol}</Td>
+                <Td>{r.saldo}€</Td>
+                <Td>
+                  <PrimaryButton onClick={() => handleLiquidar(r.user_id, r.rol)}>
+                    Mandar factura
+                  </PrimaryButton>
+                </Td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
       </Container>
     </Page>
   );


### PR DESCRIPTION
## Summary
- Avoid ambiguous `saldo` references when updating user balances
- Restyle admin payments page to use a unified table layout and show totals
- Update class acceptance to adjust balances instantly

## Testing
- `npm test`
- `cd node-server && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab8c9a9480832b99e83c384b15567d