### PR TITLE
Align student signup forms with schema and allow phone reuse

### DIFF
--- a/bbdd/sp_bbdd.sql
+++ b/bbdd/sp_bbdd.sql
@@ -138,7 +138,7 @@ CREATE TABLE IF NOT EXISTS student_project.alumno
     apellidos VARCHAR(100),
     direccion VARCHAR(100),
     NIF VARCHAR(100) NOT NULL,
-    telefono VARCHAR(25) UNIQUE,
+    telefono VARCHAR(25),
     genero VARCHAR(100),
 
         correo_tutor VARCHAR(100) NOT NULL REFERENCES student_project.tutor(correo_electronico)

--- a/src/components/AddChildModal.jsx
+++ b/src/components/AddChildModal.jsx
@@ -62,6 +62,8 @@ export default function AddChildModal({ open, onClose }) {
   const [nif, setNif] = useState('');
   const [address, setAddress] = useState('');
   const [district, setDistrict] = useState('');
+  const [barrio, setBarrio] = useState('');
+  const [postalCode, setPostalCode] = useState('');
   const [city, setCity] = useState('');
   const [saving, setSaving] = useState(false);
   const [avatar, setAvatar] = useState('');
@@ -84,7 +86,6 @@ export default function AddChildModal({ open, onClose }) {
       !address ||
       !district ||
       !city ||
-      !avatar ||
       saving
     )
       return;
@@ -102,6 +103,8 @@ export default function AddChildModal({ open, onClose }) {
             genero: gender,
             id_curso: courseId,
             distrito: district,
+            barrio,
+            codigo_postal: postalCode,
             ciudad: city,
           }
         });
@@ -118,6 +121,8 @@ export default function AddChildModal({ open, onClose }) {
           NIF: nif,
           direccion: address,
           distrito: district,
+          barrio,
+          codigo_postal: postalCode,
           ciudad: city,
           photoURL: avatar,
         };
@@ -135,6 +140,8 @@ export default function AddChildModal({ open, onClose }) {
       setNif('');
       setAddress('');
       setDistrict('');
+      setBarrio('');
+      setPostalCode('');
       setCity('');
       setAvatar('');
     } catch (err) {
@@ -227,6 +234,18 @@ export default function AddChildModal({ open, onClose }) {
             placeholder="Distrito"
             value={district}
             onChange={e => setDistrict(e.target.value)}
+          />
+          <TextInput
+            type="text"
+            placeholder="Barrio (opcional)"
+            value={barrio}
+            onChange={e => setBarrio(e.target.value)}
+          />
+          <TextInput
+            type="text"
+            placeholder="Código postal (opcional)"
+            value={postalCode}
+            onChange={e => setPostalCode(e.target.value)}
           />
           <SelectInput value={city} onChange={e => setCity(e.target.value)}>
             <option value="">Selecciona ciudad</option>

--- a/src/screens/alumno/acciones/MisAlumnos.jsx
+++ b/src/screens/alumno/acciones/MisAlumnos.jsx
@@ -6,7 +6,7 @@ import { doc, updateDoc } from 'firebase/firestore';
 import { useChild } from '../../../ChildContext';
 import { useAuth } from '../../../AuthContext';
 import { Overlay, Modal, ModalText, ModalActions, ModalButton } from '../../../components/ModalStyles';
-import { fetchCursos, registerAlumno } from '../../../utils/api';
+import { fetchCursos, fetchCities, registerAlumno } from '../../../utils/api';
 import avatars from '../../../utils/avatars';
 import PhoneInput from 'react-phone-input-2';
 import 'react-phone-input-2/lib/style.css';
@@ -95,6 +95,7 @@ export default function MisAlumnos() {
   const [gender, setGender] = useState('');
   const [courseId, setCourseId] = useState('');
   const [courses, setCourses] = useState([]);
+  const [cities, setCities] = useState([]);
   const [phone, setPhone] = useState('');
   const [phoneConfirm, setPhoneConfirm] = useState('');
   const [ownPhone, setOwnPhone] = useState(false);
@@ -111,6 +112,7 @@ export default function MisAlumnos() {
 
   useEffect(() => {
     fetchCursos().then(setCourses).catch(console.error);
+    fetchCities().then(setCities).catch(console.error);
   }, []);
 
   const addChild = async () => {
@@ -124,7 +126,6 @@ export default function MisAlumnos() {
         !address ||
         !district ||
         !city ||
-        !avatar ||
         saving
       ) return;
     setSaving(true);
@@ -332,12 +333,12 @@ export default function MisAlumnos() {
             value={postalCode}
             onChange={e => setPostalCode(e.target.value)}
           />
-          <TextInput
-            type="text"
-            placeholder="Ciudad"
-            value={city}
-            onChange={e => setCity(e.target.value)}
-          />
+          <SelectInput value={city} onChange={e => setCity(e.target.value)}>
+            <option value="">Selecciona ciudad</option>
+            {cities.map(c => (
+              <option key={c.id_ciudad} value={c.nombre}>{c.nombre}</option>
+            ))}
+          </SelectInput>
           <PrimaryButton
             onClick={addChild}
             disabled={saving}


### PR DESCRIPTION
## Summary
- Load cities for tutor student forms and capture barrio and postal code
- Allow students to reuse phone numbers by dropping unique constraint
- Standardize student form validation across tutor panels

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68aceef0c288832b9eaa603f4997c7af