### PR TITLE
Notify tutor when teacher adds class

### DIFF
--- a/src/screens/profesor/acciones/MisAlumnos.jsx
+++ b/src/screens/profesor/acciones/MisAlumnos.jsx
@@ -17,6 +17,7 @@ import {
 } from 'firebase/firestore';
 import { Link } from 'react-router-dom';
 import { formatDate } from '../../../utils/formatDate';
+import { notifyTutorClass } from '../../../utils/email';
 
 // Animación de entrada
 const fadeIn = keyframes`
@@ -502,6 +503,23 @@ export default function MisAlumnos() {
         createdAt: serverTimestamp() // timestamp para ordenar
       }
     );
+    let tutorEmail = '';
+    try {
+      const tutorSnap = await getDoc(doc(db, 'usuarios', selectedUnion.alumnoId));
+      tutorEmail = tutorSnap.exists() ? tutorSnap.data().email || '' : '';
+    } catch (err) {
+      console.error(err);
+    }
+    if (tutorEmail) {
+      await notifyTutorClass({
+        tutorEmail,
+        tutorName: selectedUnion.padreNombre || '',
+        teacherName: selectedUnion.profesorNombre || '',
+        studentName: selectedUnion.alumnoNombre || '',
+        classDate: fechaClase,
+        classTime: horaClase,
+      });
+    }
     setOpenProposalModal(false);
     show('Propuesta de clase enviada al alumno', 'success');
     // NOTA: **No** agregamos un mensaje separado en “chats”;

--- a/src/utils/email.js
+++ b/src/utils/email.js
@@ -35,3 +35,15 @@ export async function sendVerificationCode({ email, code }) {
     console.error('Failed to send verification code', err);
   }
 }
+
+export async function notifyTutorClass({ tutorEmail, tutorName, teacherName, studentName, classDate, classTime }) {
+  try {
+    await fetch(process.env.REACT_APP_NOTIFY_CLASS_API || '/api/notify-tutor-class', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tutorEmail, tutorName, teacherName, studentName, classDate, classTime })
+    });
+  } catch (err) {
+    console.error('Failed to send class notification email', err);
+  }
+}


### PR DESCRIPTION
## Summary
- Add utility to send email notifications when a tutor must confirm a class
- Notify tutor via email after teacher registers a class proposal

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68acf1798fd8832b929a1334bc5b24df