### PR TITLE
feat: add incident reporting option

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -6,6 +6,7 @@ import logo from '../assets/logonavbar.png';
 import googleLogo from '../assets/google.png';
 import appleLogo from '../assets/apple.png';
 import PasswordResetModal from './PasswordResetModal';
+import ReportIncidentModal from './ReportIncidentModal';
 
 // Firebase
 import { auth, db } from '../firebase/firebaseConfig';
@@ -291,6 +292,23 @@ const PopupLink = styled(Link)`
   }
 `;
 
+const PopupAction = styled.button`
+  display: block;
+  width: 100%;
+  background: none;
+  border: none;
+  color: #fff;
+  padding: 0.5rem 0.25rem;
+  margin-bottom: 0.75rem;
+  text-align: center;
+  font-size: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  cursor: pointer;
+  &:hover {
+    color: ${({ theme }) => theme.colors.accent};
+  }
+`;
+
 const PopupRegister = styled.p`
   font-size: 0.9rem;
   text-align: center;
@@ -367,6 +385,7 @@ export default function Navbar() {
   const [loginPassword, setLoginPassword] = useState('');
   const [loginError, setLoginError] = useState('');
   const [loginOpen, setLoginOpen] = useState(false);
+  const [incidentOpen, setIncidentOpen] = useState(false);
   const [loggingIn, setLoggingIn] = useState(false);
   const [resetOpen, setResetOpen] = useState(false);
   const loginRef = useRef(null);
@@ -520,6 +539,9 @@ export default function Navbar() {
                 </AccessButton>
                 <LoginPopup show={loginOpen}>
                   <PopupLink to={`/perfil/${user?.uid}`}>Mi Cuenta</PopupLink>
+                  <PopupAction onClick={() => { setIncidentOpen(true); setLoginOpen(false); }}>
+                    Reportar incidencia
+                  </PopupAction>
                   <PopupButton onClick={handleLogout}>
                     Cerrar sesión
                   </PopupButton>
@@ -595,6 +617,12 @@ export default function Navbar() {
       </Container>
     </Nav>
     <PasswordResetModal open={resetOpen} onClose={() => setResetOpen(false)} />
+    <ReportIncidentModal
+      open={incidentOpen}
+      onClose={() => setIncidentOpen(false)}
+      defaultName={userData?.nombre || ''}
+      defaultEmail={user?.email || ''}
+    />
     </>
   );
 }

--- a/src/components/ReportIncidentModal.jsx
+++ b/src/components/ReportIncidentModal.jsx
@@ -1,0 +1,126 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { Overlay, Modal, ModalTitle, ModalText, ModalActions, ModalButton } from './ModalStyles';
+import { reportIncident } from '../utils/api';
+
+const CloseButton = styled.button`
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  cursor: pointer;
+`;
+
+const Input = styled.input`
+  width: 100%;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 1rem;
+`;
+
+const TextArea = styled.textarea`
+  width: 100%;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 1rem;
+  resize: vertical;
+  min-height: 120px;
+`;
+
+const ErrorText = styled.p`
+  color: #ff6b6b;
+  font-size: 0.9rem;
+  text-align: center;
+  margin-bottom: 0.5rem;
+`;
+
+const SuccessText = styled.p`
+  color: #02b36e;
+  font-size: 0.9rem;
+  text-align: center;
+  margin-bottom: 0.5rem;
+`;
+
+export default function ReportIncidentModal({ open, onClose, defaultName = '', defaultEmail = '' }) {
+  const [name, setName] = useState(defaultName);
+  const [email, setEmail] = useState(defaultEmail);
+  const [message, setMessage] = useState('');
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setName(defaultName);
+      setEmail(defaultEmail);
+      setMessage('');
+      setError('');
+      setSuccess('');
+    }
+  }, [open, defaultName, defaultEmail]);
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    setError('');
+    setSuccess('');
+    setSending(true);
+    try {
+      await reportIncident({ nombre: name, email, mensaje: message });
+      setSuccess('Incidencia enviada correctamente.');
+      setMessage('');
+    } catch (err) {
+      setError(err.message || 'Error enviando incidencia');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <Overlay>
+      <Modal>
+        <CloseButton onClick={onClose}>✕</CloseButton>
+        <ModalTitle>Reportar incidencia</ModalTitle>
+        <ModalText>Cuéntanos el problema que has encontrado.</ModalText>
+        {error && <ErrorText>{error}</ErrorText>}
+        {success && <SuccessText>{success}</SuccessText>}
+        <form onSubmit={handleSubmit}>
+          <Input
+            type="text"
+            placeholder="Tu nombre"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            required
+          />
+          <Input
+            type="email"
+            placeholder="Tu correo electrónico"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
+          />
+          <TextArea
+            placeholder="Describe la incidencia"
+            value={message}
+            onChange={e => setMessage(e.target.value)}
+            required
+          />
+          <ModalActions>
+            <ModalButton type="button" onClick={onClose}>Cancelar</ModalButton>
+            <ModalButton primary type="submit" disabled={sending}>
+              {sending ? 'Enviando...' : 'Enviar'}
+            </ModalButton>
+          </ModalActions>
+        </form>
+      </Modal>
+    </Overlay>
+  );
+}
+

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -149,3 +149,12 @@ export async function cancelOffer({ offerId, pujaId, role }) {
   });
   return handleResponse(res);
 }
+
+export async function reportIncident(data) {
+  const res = await fetch(`${API_URL}/incidencias`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  return handleResponse(res);
+}


### PR DESCRIPTION
## Summary
- add modal to report incidents from navbar
- send incidents to backend, database, firestore, and email

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68bb27425e18832ba48468455b39dba2