### PR TITLE
Redirect root path to home page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -74,6 +74,7 @@ function AppContent() {
     <AppContainer>
       {loading && <LoadingScreen fullscreen />}
       <Routes>
+          <Route path="/" element={<Navigate to="/home" replace />} />
           {/* Sin Navbar/Footer */}
           <Route path="/alta-profesor" element={<SignUpProfesor />} />
           <Route path="/alta-tutor"    element={<SignUpTutor />} />


### PR DESCRIPTION
## Summary
- Redirect root path `/` to `/home` so visiting the base URL lands on the home page

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c734336dcc832bb80ebce8bd552c2a